### PR TITLE
packer-rocm: configurable packages w/ 'amdgpu_install'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packer-maas

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -46,9 +46,15 @@ cd packer-maas/ubuntu
 PACKER_LOG=1 packer build \
     -var rocm_release=6.2.2 \
     -var rocm_release_build=6.2.60202-1 \
+    -var amdgpu_install='["amdgpu-dkms", "rocm"]' \
     -only=qemu.rocm .
 ```
-The artifact is named `ubuntu-rocm.dd.gz`. The `rocm_release` variables are optional. Potentially-changing defaults are provided.
+
+The artifact is named `ubuntu-rocm.dd.gz`. These _Packer_ variables are optional, defaults are shown:
+
+* `rocm_release`
+* `rocm_release_build`
+* `amdgpu_install`
 
 ### Proxy
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -1,7 +1,7 @@
 # packer-rocm
 
 [MaaS](https://maas.io/)-enabled [Packer](https://www.packer.io/) images
-with [ROCm](https://www.amd.com/en/products/software/rocm.html) installed.
+with [amdgpu-install](https://amdgpu-install.readthedocs.io/en/latest/) and [ROCm](https://www.amd.com/en/products/software/rocm.html) installed.
 Builds on the [canonical/packer-maas](https://github.com/canonical/packer-maas/)
 project.
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -5,15 +5,34 @@ with [amdgpu-install](https://amdgpu-install.readthedocs.io/en/latest/) and [ROC
 Builds on the [canonical/packer-maas](https://github.com/canonical/packer-maas/)
 project.
 
-## One-time Setup
 
-### Requirements
+## Building
+
+### Playbook
+
+1. Clone _ADA_ repository:
+
+    ```shell
+    git clone https://github.com/nod-ai/ADA.git
+    ```
+
+2. Run:
+
+    ```shell
+    ansible-playbook playbooks/build.yml
+    ```
+
+### Manual
+
+#### One-time Setup
+
+#### Requirements
 
 * [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible-core`, examples: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
 * `qemu`
 
-### Sources
+#### Sources
 
 1. Clone repositories:
 
@@ -36,19 +55,19 @@ project.
     packer init .
     ```
 
-## Building
+4. Build
 
-```shell
-# Change working directory to the prepared sources
-cd packer-maas/ubuntu
+    ```shell
+    # Change working directory to the prepared sources
+    cd packer-maas/ubuntu
 
-# Build
-PACKER_LOG=1 packer build \
-    -var rocm_release=6.2.2 \
-    -var rocm_release_build=6.2.60202-1 \
-    -var amdgpu_install='["amdgpu-dkms", "rocm"]' \
-    -only=qemu.rocm .
-```
+    # Build
+    PACKER_LOG=1 packer build \
+        -var rocm_release=6.2.2 \
+        -var rocm_release_build=6.2.60202-1 \
+        -var amdgpu_install='["amdgpu-dkms", "rocm"]' \
+        -only=qemu.rocm .
+    ```
 
 The artifact is named `ubuntu-rocm.dd.gz`. These _Packer_ variables are optional, defaults are shown:
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -8,6 +8,12 @@ project.
 
 ## Building
 
+### Requirements
+
+* [packer](https://developer.hashicorp.com/packer/docs/install)
+* `ansible-core`, examples: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
+* `qemu`
+
 ### Playbook
 
 1. Clone _ADA_ repository:
@@ -23,16 +29,6 @@ project.
     ```
 
 ### Manual
-
-#### One-time Setup
-
-#### Requirements
-
-* [packer](https://developer.hashicorp.com/packer/docs/install)
-* `ansible-core`, examples: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
-* `qemu`
-
-#### Sources
 
 1. Clone repositories:
 
@@ -69,13 +65,15 @@ project.
         -only=qemu.rocm .
     ```
 
+### I/O
+
 The artifact is named `ubuntu-rocm.dd.gz`. These _Packer_ variables are optional, defaults are shown:
 
 * `rocm_release`
 * `rocm_release_build`
 * `amdgpu_install`
 
-### Proxy
+#### Proxy
 
 If the build requires a proxy for downloading the ISO, updates, or ROCm... these _environment variables_ are respected:
 

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -1,0 +1,40 @@
+---
+# vim: ft=yaml.ansible
+- name: Build 'packer-rocm'
+  hosts: localhost
+  gather_facts: false
+  vars:
+    packer_rocm_dir: "{{ (playbook_dir, '..') | path_join }}"
+    packer_maas_dir: "{{ (packer_rocm_dir, 'packer-maas') | path_join }}"
+  tasks:
+    - name: Preparation
+      tags: ['prep']
+      block:
+        - name: "Manage clone for 'packer-maas' under ADA"
+          ansible.builtin.git:
+            repo: "https://github.com/canonical/packer-maas.git"
+            dest: "{{ packer_maas_dir }}"
+
+        - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
+          ansible.posix.synchronize:
+            src: "{{ packer_rocm_dir }}/"  # trailing '/' on source is significant; copying *contents* of the dir
+            dest: "{{ packer_maas_dir }}"
+            rsync_opts:
+              - "--exclude='*.md'"
+              - "--exclude='NOTICE'"
+              - "--exclude='LICENSE'"
+              - "--exclude='packer-maas'"
+
+        - name: "Ensure Packer plugins are installed"
+          ansible.builtin.command: "packer init {{ (packer_maas_dir, 'ubuntu') | path_join }}"
+          changed_when: false
+
+    - name: Build
+      ansible.builtin.command: packer build -var rocm_release=6.2.2 -var rocm_release_build=6.2.60202-1 -only=qemu.rocm .
+      vars:
+        build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
+      args:
+        chdir: "{{ build_dir }}"
+        creates: "{{ (build_dir, 'ubuntu-rocm.dd.gz') | path_join }}" # avoid overwriting - require delete
+      environment:
+        PACKER_LOG: '1'  # wanted as str

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -14,6 +14,7 @@
           ansible.builtin.git:
             repo: "https://github.com/canonical/packer-maas.git"
             dest: "{{ packer_maas_dir }}"
+            version: "{{ packer_maas_tag | default('v1.2.0') }}"
 
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:
@@ -30,11 +31,16 @@
           changed_when: false
 
     - name: Build
-      ansible.builtin.command: packer build -var rocm_release=6.2.2 -var rocm_release_build=6.2.60202-1 -only=qemu.rocm .
-      vars:
-        build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
-      args:
+      ansible.builtin.command:
+        cmd: >
+          packer build
+          -var headless={{ headless | default('true') }}
+          -var rocm_release={{ rocm_release | default('6.2.2') }}
+          -var rocm_release_build={{ rocm_release_build | default('6.2.60202-1') }}
+          -only=qemu.rocm .
         chdir: "{{ build_dir }}"
         creates: "{{ (build_dir, 'ubuntu-rocm.dd.gz') | path_join }}" # avoid overwriting - require delete
+      vars:
+        build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
       environment:
         PACKER_LOG: '1'  # wanted as str

--- a/packer-rocm/playbooks/rocm.yml
+++ b/packer-rocm/playbooks/rocm.yml
@@ -34,9 +34,13 @@
         name: "{{ rocm_amdgpu_pkg['redhat'] if ansible_os_family in ['RedHat'] else omit }}"
         deb: "{{ rocm_amdgpu_pkg['debian'] if ansible_os_family in ['Debian'] else omit }}"
 
-    - name: Install amdgpu-dkms + ROCm
+    - name: "Install {{ _pkgs }}"
       ansible.builtin.package:
-        name: ["amdgpu-dkms", "rocm"]
+        name: "{{ _pkgs }}"
         state: present
         update_cache: true
+      vars:
+        # serialized through 'extra_arguments' with Packer/the Ansible plugin
+        # use 'split' filter to return this comma-separated string to a list [if applicable]
+        _pkgs: "{{ amdgpu_install | split(',') }}"  # default: '["amdgpu-dkms", "rocm"]', see 'ubuntu-rocm.variables.pkr.hcl'
 # vim: ft=yaml.ansible

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -26,8 +26,8 @@ source "qemu" "rocm" {
   ssh_handshake_attempts = 500
   ssh_username           = "ubuntu"
   ssh_password           = var.ssh_ubuntu_password
-  ssh_wait_timeout       = var.timeout
-  ssh_timeout            = var.timeout
+  ssh_wait_timeout       = "1h"
+  ssh_timeout            = "1h"
   # debug/discard
   # ssh_pty = true
   # ssh_agent_auth = false

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -56,7 +56,8 @@ build {
       "-e", "ansible_python_interpreter=/usr/bin/python3",  # work around Packer/SSH proxy+client limitations
       "--scp-extra-args", "'-O'",
       "-e", "rocm_release_build=${var.rocm_release_build}",  # pass ROCm requests
-      "-e", "rocm_release=${var.rocm_release}"
+      "-e", "rocm_release=${var.rocm_release}",
+      "-e", "amdgpu_install=${join(",", var.amdgpu_install)}"
     ]
   }
 

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -13,6 +13,12 @@ variable "rocm_release_build" {
   default = "6.2.60202-1"
 }
 
+variable "amdgpu_install" {
+  type = list(string)
+  default = ["amdgpu-dkms", "rocm"]
+  description = "The packages to install with Ansible [after installing 'amdgpu-install']"
+}
+
 packer {
   required_plugins {
     ansible = {


### PR DESCRIPTION
Realizing I overdid it a bit, assuming both `amdgpu-dkms` and `rocm` will want to be installed. The packages included in the image is now configurable with `amdgpu_install`.

One may now opt to build an image only with `amdgpu-dkms`, just `amdgpu-install`, or as many extra packages are desired.

Up next: `ga` _(or equivalent)_; if `repo.radeon.com` is used or Artifactory/another URL for `amdgpu-install`