### PR TITLE
Fault tolerance with conflicting destinations

### DIFF
--- a/redfish-exporter/main.go
+++ b/redfish-exporter/main.go
@@ -44,7 +44,6 @@ func main() {
 	// Subscribe the listener to the event stream for all servers
 	subscriptionMap, err := CreateSubscriptionsForAllServers(AppConfig.RedfishServers, AppConfig.SubscriptionPayload)
 	if err != nil {
-		// TODO detect if error is due to already being subscribed, and delete/re-add subscription.
 		log.Fatalf("Failed to create subscriptions: %v", err)
 	}
 

--- a/redfish-exporter/redfish_utils.go
+++ b/redfish-exporter/redfish_utils.go
@@ -79,6 +79,7 @@ func createSubscription(server RedfishServer, SubscriptionPayload SubscriptionPa
 		return "", fmt.Errorf("failed to get event service for server: %v", err)
 	}
 
+	DeleteExistingSubscription(server, SubscriptionPayload)
 	// Create the subscription based on the Redfish version
 	if isV1_5() {
 		return createV1_5Subscription(eventService, SubscriptionPayload)
@@ -187,6 +188,45 @@ func deleteSubscriptionFromServer(server RedfishServer, subscriptionURI string) 
 	}
 
 	return nil
+}
+
+// Unsubscribes/deletes overlapping subscriptions from the server
+func DeleteExistingSubscription(server RedfishServer, subscriptionPayload SubscriptionPayload) error {
+	subscriptions, err := GetServerSubscriptions(server)
+	if err != nil {
+		return err
+	}
+	for _, subscription := range subscriptions {
+		if subscription.Destination == subscriptionPayload.Destination {
+			err := deleteSubscriptionFromServer(server, subscription.ODataID)
+			if err != nil {
+				return fmt.Errorf("failed to delete event subscription %s, on server %s: %v", subscription.ID, server.IP, err)
+			} else {
+				log.Printf("successfully deleted overlapping event subscription %s from server %s", subscription.ID, server.IP)
+			}
+		}
+	}
+	return nil
+}
+
+// Gets all subscriptions currently active on the given server
+func GetServerSubscriptions(server RedfishServer) ([]*redfish.EventDestination, error) {
+	c, err := getRedfishClient(server)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to redfish server %s: %v", server.IP, err)
+	}
+	defer c.Logout()
+
+	es, err := c.Service.EventService()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get event service from server %s: %v", server.IP, err)
+	}
+
+	subscriptions, err := es.GetEventSubscriptions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get event subscriptions on server %s: %v", server.IP, err)
+	}
+	return subscriptions, nil
 }
 
 // Retrieve the server's credentials from the config based on IP


### PR DESCRIPTION
Added fault tolerance when the server already has a subscription with conflicting Destination field.

The check happens before sending and not as response to an error, as the the responses from the BMC seem to vary between version/manufacturers, making parsing it trickier. 