### PR TITLE
Add slurm API call counters to prometheus

### DIFF
--- a/redfish-exporter/README.md
+++ b/redfish-exporter/README.md
@@ -116,6 +116,20 @@ curl localhost:8000/redfish/v1
 ```
 Note that SSL can be enabled using the provided dev certificate and key.
 
+### Slurm Integration
+
+1. Refer to [this](./api/README.md) guide for generating the Slurm REST API.
+
+2. Required Configurations for Enabling Slurm:
+
+- **SLURM_TOKEN**: Obtain the token by running the following command on the Slurm control node (where slurmrestd is running):
+    ```sh
+    scontrol token username=root lifespan=18000
+    ```
+    (`lifespan` is specified in seconds)
+
+- **SLURM_CONTROL_NODE**: The hostname or IP address of the Slurm control node where the REST server is running.
+
 ### Integration Testing
 
 To run the integration tests, use: `make integration-test`

--- a/redfish-exporter/integration_test.sh
+++ b/redfish-exporter/integration_test.sh
@@ -129,6 +129,8 @@ check_metric() {
 
 check_metric "RedFishEvents_recieved"
 check_metric "RedFishEvents_processing_time"
+check_metric "SlurmAPI_failure"
+check_metric "SlurmAPI_success"
 
 log "Integration test completed successfully"
 

--- a/redfish-exporter/listener.go
+++ b/redfish-exporter/listener.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nod-ai/ADA/redfish-exporter/metrics"
 	"github.com/nod-ai/ADA/redfish-exporter/slurm"
 )
 
@@ -221,7 +222,7 @@ func (s *Server) processRequest(AppConfig Config, conn net.Conn, req *http.Reque
 				// Sending event belongs to redfish_utils. Each server may have different slurm node associated, and redfish_servers has the info/map.
 				if s.slurmQueue != nil {
 					redfishServerInfo := getServerInfo(AppConfig.RedfishServers, fmt.Sprintf("https://%v", ip))
-					s.slurmQueue.Add(triggerEvent.Action, redfishServerInfo.SlurmNode)
+					s.slurmQueue.Add(redfishServerInfo.IP, redfishServerInfo.SlurmNode, triggerEvent.Severity, triggerEvent.Action)
 				}
 				break
 			}
@@ -234,8 +235,8 @@ func (s *Server) processRequest(AppConfig Config, conn net.Conn, req *http.Reque
 
 	// Update metrics using variables from metrics.go
 	timestamp := float64(time.Now().Unix())
-	eventCountMetric.WithLabelValues(ip, eventType).Inc()
-	eventProcessingTimeMetric.WithLabelValues(ip, eventType).Set(timestamp)
+	metrics.EventCountMetric.WithLabelValues(ip, eventType).Inc()
+	metrics.EventProcessingTimeMetric.WithLabelValues(ip, eventType).Set(timestamp)
 
 	// Send a 200 OK response
 	response := &http.Response{

--- a/redfish-exporter/metrics/metrics.go
+++ b/redfish-exporter/metrics/metrics.go
@@ -14,13 +14,13 @@
  *  limitations under the License.
 **/
 
-package main
+package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var eventCountMetric = prometheus.NewCounterVec(
+var EventCountMetric = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "RedFishEvents_recieved",
 		Help: "Total number of events processed",
@@ -28,7 +28,7 @@ var eventCountMetric = prometheus.NewCounterVec(
 	[]string{"SourceIP", "EventType"}, // Define the labels you want to use
 )
 
-var eventProcessingTimeMetric = prometheus.NewGaugeVec(
+var EventProcessingTimeMetric = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "RedFishEvents_processing_time",
 		Help: "Time taken to process events",
@@ -36,9 +36,27 @@ var eventProcessingTimeMetric = prometheus.NewGaugeVec(
 	[]string{"SourceIP", "EventType"}, // Define the labels you want to use
 )
 
+var SlurmAPIFailureMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "SlurmAPI_failure",
+		Help: "Total number of Slurm API calls that failed",
+	},
+	[]string{"SourceIP", "SlurmNodeName", "EventSeverity", "EventAction"}, // Define the labels you want to use
+)
+
+var SlurmAPISuccessMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "SlurmAPI_success",
+		Help: "Total number of Slurm API calls that succeeded",
+	},
+	[]string{"SourceIP", "SlurmNodeName", "EventSeverity", "EventAction"}, // Define the labels you want to use
+)
+
 func init() {
 	// Register the counter with Prometheus's default registry
-	prometheus.MustRegister(eventCountMetric)
+	prometheus.MustRegister(EventCountMetric)
 	// Register the gauge with Prometheus's default registry
-	prometheus.MustRegister(eventProcessingTimeMetric)
+	prometheus.MustRegister(EventProcessingTimeMetric)
+	prometheus.MustRegister(SlurmAPIFailureMetric)
+	prometheus.MustRegister(SlurmAPISuccessMetric)
 }


### PR DESCRIPTION
And this is the output from `/metrics`:


```
# HELP SlurmAPI_success Total number of Slurm API calls that succeeded
# TYPE SlurmAPI_success counter
SlurmAPI_success{EventAction="DrainNode",EventMessageId="IDRAC.2.9.CPU0001",SlurmNodeName="computenode1",SourceIP="https://10.30.64.17"} 2

# HELP SlurmAPI_failure Total number of Slurm API calls that failed
# TYPE SlurmAPI_failure counter
SlurmAPI_failure{EventAction="DrainNode",EventMessageId="IDRAC.2.9.CPU0001",SlurmNodeName="computenode1",SourceIP="https://10.30.64.17"} 1
```