### PR TITLE
packer-rocm: introduce `packages` dir

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -34,6 +34,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     git clone https://github.com/nod-ai/ADA.git
     ```
 
+    Place any `.deb` or `.rpm` packages to include with the image(s) in `packer-rocm/packages/`
+
 2. Copy assets from _ADA_ `packer-rocm` to the _Canonical_ `packer-maas` source:
 
     ```shell
@@ -53,8 +55,6 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     ```shell
     # Change working directory to the prepared sources
     cd packer-maas/ubuntu
-
-    # Optional: place any package files to copy and install in the 'packages' directory (RPM or DEB)
 
     # Build
     PACKER_LOG=1 packer build \
@@ -81,7 +81,7 @@ The artifact is named `ubuntu-rocm.dd.gz`. When building with `ansible-pull`, it
 
 #### Proxy
 
-If the build requires a proxy for downloading the ISO, updates, or ROCm... these _environment variables_ are respected:
+These _environment variables_ are respected:
 
 * `http_proxy`
 * `https_proxy`

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -34,7 +34,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     git clone https://github.com/nod-ai/ADA.git
     ```
 
-    Place any `.deb` or `.rpm` packages to include with the image(s) in `packer-rocm/packages/`
+    Place any `.deb` or `.rpm` packages to include with the image(s) in `ADA/packer-rocm/packages/`
 
 2. Copy assets from _ADA_ `packer-rocm` to the _Canonical_ `packer-maas` source:
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -54,6 +54,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     # Change working directory to the prepared sources
     cd packer-maas/ubuntu
 
+    # Optional: place any package files to copy and install in the 'packages' directory (RPM or DEB)
+
     # Build
     PACKER_LOG=1 packer build \
         -var kernel=linux-generic \

--- a/packer-rocm/packages/README.md
+++ b/packer-rocm/packages/README.md
@@ -1,0 +1,5 @@
+# packages
+
+Files placed here will be copied into the _Packer_ builder VM. The _intended_ use includes `.deb` or `.rpm` files.
+
+An [Ansible playbook](../playbooks/package-globber.yml) used as a [provisioner](https://developer.hashicorp.com/packer/docs/provisioners/) will install those which are distribution-appropriate.

--- a/packer-rocm/packages/README.md
+++ b/packer-rocm/packages/README.md
@@ -2,4 +2,4 @@
 
 Files placed here will be copied into the _Packer_ builder VM. The _intended_ use includes `.deb` or `.rpm` files.
 
-An [Ansible playbook](../playbooks/package-globber.yml) used as a [provisioner](https://developer.hashicorp.com/packer/docs/provisioners/) will install those which are distribution-appropriate.
+Packages appropriate for the image will be installed by an [Ansible playbook](../playbooks/package-globber.yml), used by _Packer_ as a [provisioner](https://developer.hashicorp.com/packer/docs/provisioners/).

--- a/packer-rocm/playbooks/package-globber.yml
+++ b/packer-rocm/playbooks/package-globber.yml
@@ -1,0 +1,35 @@
+---
+# vim: ft=yaml.ansible
+- name: Package Globber  # the Packer 'file' provisioner copies the files to the builder VM; this processes/installs
+  hosts: default
+  become: true
+  environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
+    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
+    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
+  vars:
+    packages: '/tmp/packages'
+    pkg_exts:  # mapped by 'ansible_os_family' to glob [relevant] file patterns
+      Debian: ".deb"
+      RedHat: ".rpm"
+  tasks:
+
+    # 'fileglob' works on the controller; must 'find' when potentially mixing local/remote client usecases
+    - name: Find Packages
+      ansible.builtin.find:
+        paths: "{{ packages }}"
+        patterns:
+          - "*{{ pkg_exts[ansible_os_family] }}"
+        recurse: true
+      register: pkg_search
+
+    - name: Set 'found_pkgs' fact
+      ansible.builtin.set_fact:
+        found_pkgs: "{{ pkg_search.files | map(attribute='path') }}"
+
+    - name: Loop/Install 'found_pkgs'
+      ansible.builtin.package:  # RE: unusual templating - file paths don't work as well for 'name' on Debian/derivatives, requiring 'deb'
+        deb: "{{ item if ansible_os_family in ['Debian'] else omit }}"
+        name: "{{ item if ansible_os_family in ['RedHat'] else omit }}"
+        state: present
+      loop: "{{ found_pkgs }}"

--- a/packer-rocm/playbooks/package-globber.yml
+++ b/packer-rocm/playbooks/package-globber.yml
@@ -10,8 +10,8 @@
   vars:
     packages: '/tmp/packages'
     pkg_exts:  # mapped by 'ansible_os_family' to glob [relevant] file patterns
-      Debian: ".deb"
-      RedHat: ".rpm"
+      Debian: '.deb'
+      RedHat: '.rpm'
   tasks:
 
     # 'fileglob' works on the controller; must 'find' when potentially mixing local/remote client usecases

--- a/packer-rocm/playbooks/rocm.yml
+++ b/packer-rocm/playbooks/rocm.yml
@@ -123,3 +123,5 @@
         state: present
         update_cache: true
       when: rocm_extras is defined
+
+# vim: ft=yaml.ansible


### PR DESCRIPTION
For packages not available in a repository or generally over the internet, a `packages` directory has been introduced. Any `.rpm` or `.deb` files placed here will be installed as part of image creation!