### PR TITLE
packer-rocm/tuned_profile: init

### DIFF
--- a/packer-rocm/playbooks/roles/tuned_profile/README.md
+++ b/packer-rocm/playbooks/roles/tuned_profile/README.md
@@ -1,0 +1,75 @@
+tuned\_profile
+=========
+
+Role to manage [tuned](http://www.tuned-project.org/), profiles, and related Ansible facts.
+
+
+Role Variables
+--------------
+
+| Variable | Description |
+|-----|-----|
+| `tuned_profile_name` | Name of the custom `tuned` profile to create. |
+| `tuned_profile_scripts` | Optional list of script files to copy from the controller/repository, supporting the profile. |
+| `tuned_profile_reboot` | If activating the profile requires _(and gets)_ a reboot to become effective. Default is False.<br/>Intended for those with 'cmdline' options. |
+| `tuned_profile_params` | Required, dictionary of `tuned.conf` sections with each key being a plugin. |
+
+
+Preview
+--------------
+
+Profile variables _(minified)_, see [our playbook](../../playbook.yml) for the most current example:
+
+```yaml
+tuned_profile_name: amd_custom
+tuned_profile_scripts:
+  - acs_disable.sh
+tuned_profile_params:
+  main:
+    description: "Ansible managed; do not edit. Please 'include'/extend in other profiles instead."
+    summary: 'AMD site customizations'
+    include: 'network-throughput'  # base profile to build upon
+  bootloader:  # one of many plugins; shouldn't be repeated. the 'cmdline_...' keys should be globally unique
+    cmdline_amdsre_debug: 'earlyprintk=ttyS1,keep'
+    cmdline_amdsre_iommu: 'amd_iommu=on iommu=pt nokaslr'
+    cmdline_amdsre_pci: 'pci=realloc=off pcie_aspm=off'
+  disableacs:  # scripts may get their own section names to avoid repeat limitations
+    type: script
+    script: '${i:PROFILE_DIR}/acs_disable.sh'
+  sysctl:
+    kernel.numa_balancing: 0
+    dev.raid.speed_limit_min: 100000
+    dev.raid.speed_limit_max: 20000000
+```
+
+Rendered:
+
+```ini
+$ cat /etc/tuned/profiles/amd_custom/tuned.conf 
+#
+# Ansible managed
+#
+
+[main]
+description=Ansible managed; do not edit. Please 'include'/extend in other profiles instead.
+summary=AMD site customizations
+include=latency-performance
+
+[bootloader]
+cmdline_amdsre_debug=earlyprintk=ttyS1,keep
+cmdline_amdsre_iommu=amd_iommu=on iommu=pt nokaslr
+cmdline_amdsre_pci=pci=realloc=off pcie_aspm=off
+
+[disableacs]
+type=script
+script=${i:PROFILE_DIR}/acs_disable.sh
+
+[sysctl]
+kernel.numa_balancing=0
+dev.raid.speed_limit_min=100000
+dev.raid.speed_limit_max=20000000
+
+[variables]
+include=/etc/tuned/amd-vars.conf
+```
+

--- a/packer-rocm/playbooks/roles/tuned_profile/README.md
+++ b/packer-rocm/playbooks/roles/tuned_profile/README.md
@@ -33,6 +33,7 @@ tuned_profile_params:
     cmdline_amdsre_debug: 'earlyprintk=ttyS1,keep'
     cmdline_amdsre_iommu: 'amd_iommu=on iommu=pt nokaslr'
     cmdline_amdsre_pci: 'pci=realloc=off pcie_aspm=off'
+    cmdline_amdsre_perf_security: 'msr.allow_writes=on'
   disableacs:  # scripts may get their own section names to avoid repeat limitations
     type: script
     script: '${i:PROFILE_DIR}/acs_disable.sh'
@@ -59,6 +60,7 @@ include=latency-performance
 cmdline_amdsre_debug=earlyprintk=ttyS1,keep
 cmdline_amdsre_iommu=amd_iommu=on iommu=pt nokaslr
 cmdline_amdsre_pci=pci=realloc=off pcie_aspm=off
+cmdline_amdsre_perf_security=msr.allow_writes=on
 
 [disableacs]
 type=script

--- a/packer-rocm/playbooks/roles/tuned_profile/README.md
+++ b/packer-rocm/playbooks/roles/tuned_profile/README.md
@@ -18,7 +18,7 @@ Role Variables
 Preview
 --------------
 
-Profile variables _(minified)_, see [our playbook](../../playbook.yml) for the most current example:
+Profile variables _(minified)_, see [our playbook](../../tuned.yml) for the most current example:
 
 ```yaml
 tuned_profile_name: amd_custom

--- a/packer-rocm/playbooks/roles/tuned_profile/defaults/main.yml
+++ b/packer-rocm/playbooks/roles/tuned_profile/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# this seems common; may deserve a dictionary sorted by 'ansible_os_family' if packaging drifts
+tuned_main_config: '/etc/tuned/tuned-main.conf'  # noqa: var-naming[no-role-prefix]
+
+# after v2.23.0, 'tuned' profiles received another subdirectory - it attempts to migrate if upgraded, we just follow
+tuned_profile_basedir: "{{ '/etc/tuned' if ansible_facts.packages['tuned'][0].version is version('2.23.0-1', '<') else '/etc/tuned/profiles' }}"
+
+# assume the profile being created should be enabled with 'tuned-adm profile ...'
+tuned_profile_enable: true
+
+# when enabling the custom profile, opt to reboot (ie: apply cmdline options); most do not require this - opt in
+tuned_profile_reboot: false
+
+# if the service should be restarted on template change, assume yes - allow opting out (ie: image builds)
+tuned_profile_restart: true
+
+# optional script files to copy into the profile directory
+tuned_profile_scripts: []

--- a/packer-rocm/playbooks/roles/tuned_profile/files/acs_disable.sh
+++ b/packer-rocm/playbooks/roles/tuned_profile/files/acs_disable.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Disable ACS on every device that supports it; offers verification for 'tuned'
+#
+
+function force_acs() {
+        # default path/function - if not 'verify' mode, *set* ACS/DT mode for devices
+        for BDF in $(lspci -d "*:*:*" | awk '{print $1}'); do
+                # skip if it doesn't support ACS
+                if ! setpci -v -s "${BDF}" ECAP_ACS+0x6.w > /dev/null 2>&1 ; then
+                        #echo "${BDF} does not support ACS, skipping"
+                        continue
+                fi
+                echo "Disabling ACS on $(lspci -s "${BDF}")"
+                if ! setpci -v -s "${BDF}" ECAP_ACS+0x6.w=0000 ; then
+                        echo "Error enabling directTrans ACS on ${BDF}"
+                        continue
+                fi
+                NEW_VAL=$(setpci -v -s "${BDF}" ECAP_ACS+0x6.w | awk '{print $NF}')
+                if [ "${NEW_VAL}" != "0000" ]; then
+                        echo "Failed to enabling directTrans ACS on ${BDF}"
+                        continue
+                fi
+        done
+}
+
+function verify() {
+        # if the first/only arg is 'verify', this is called to *check* ACS on all devices
+	ACS_ENABLED_CT=$(lspci -vvv | grep -c "ACSCtl.*SrcValid+")
+	printf "Verification mode enabled for 'tuned-adm verify'\nFound %s devices with ACS enabled\n" "$ACS_ENABLED_CT"
+	# exit with rc matching the number of devices with ACS enabled; > 0 is failure
+	exit "$ACS_ENABLED_CT"
+}
+
+case $1 in
+        verify)
+		verify
+                ;;
+        *)
+                force_acs
+                ;;
+esac

--- a/packer-rocm/playbooks/roles/tuned_profile/files/tuned.fact
+++ b/packer-rocm/playbooks/roles/tuned_profile/files/tuned.fact
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Provides Ansible with facts about the 'tuned' service on a host
+
+ie: current profile (if running), otherwise 'inactive'
+"""
+from os import path
+from json import dumps
+
+def readcm(file):
+    '''Toy function for file reading/content-stripping'''
+    with open(file, 'r', encoding='utf-8') as _f:
+        return _f.read().strip()
+
+def is_tuned_running():
+    '''Attempts to read the PID file for 'tuned' and /proc to report status'''
+    if not path.exists(PID_FILE):
+        return False
+
+    try:
+        pid = readcm(PID_FILE)
+        pidfile_content = readcm(f'/proc/{pid}/comm')
+    except FileNotFoundError:
+        return False
+
+    if pidfile_content == 'tuned':
+        return True
+    return False
+
+# the 'active' file exists even when the service is stopped; cannot indicate running state
+ACTIVE_FILE = '/etc/tuned/active_profile'
+PID_FILE = '/run/tuned/tuned.pid'
+TUNED_RUNNING = is_tuned_running()
+
+print(dumps({
+    "active": TUNED_RUNNING,
+    "selected_profile": readcm(ACTIVE_FILE) if TUNED_RUNNING else "inactive"
+}), flush=True)

--- a/packer-rocm/playbooks/roles/tuned_profile/handlers/main.yml
+++ b/packer-rocm/playbooks/roles/tuned_profile/handlers/main.yml
@@ -1,0 +1,28 @@
+---
+# handlers file for 'tuned_profile' role
+
+- name: Restart 'tuned' on profile or config change
+  become: true
+  ansible.builtin.service:
+    name: tuned
+    state: restarted
+  listen: tuned_restart
+  when: tuned_profile_restart is truthy(convert_bool=True)
+  tags:
+    - always
+
+- name: Re-gather facts on changes
+  ansible.builtin.setup:
+  listen: ansible_setup
+  tags:
+    - always
+
+- name: Reboot when enabling profile
+  ansible.builtin.reboot:
+    reboot_timeout: 1200
+    msg: "Rebooting host; will wait 20 minutes"
+  become: true
+  listen: tuned_handler_reboot
+  when: tuned_profile_reboot is truthy(convert_bool=True)
+  tags:
+    - always

--- a/packer-rocm/playbooks/roles/tuned_profile/meta/argument_specs.yml
+++ b/packer-rocm/playbooks/roles/tuned_profile/meta/argument_specs.yml
@@ -1,0 +1,25 @@
+---
+argument_specs:
+  main:
+    short_description: Role to manage `tuned` profiles and Ansible facts
+    options:
+      tuned_profile_name:
+        required: true
+        type: str
+        description: "Name of the custom `tuned` profile to create."
+      tuned_profile_enable:
+        required: false
+        type: bool
+        description: "If the profile should be enabled with 'tuned-adm profile ...', assumed true"
+      tuned_profile_reboot:
+        required: false
+        type: bool
+        description: "If activating the profile requires (and gets) a reboot to become effective. Default is False. Intended for those with 'cmdline' options."
+      tuned_profile_scripts:
+        required: false
+        type: list
+        description: "Script files to copy from the controller/repository, supporting the profile."
+      tuned_profile_params:
+        required: true
+        type: dict
+        description: "Sections of 'tuned.conf' with each dictionary key being a plugin"

--- a/packer-rocm/playbooks/roles/tuned_profile/tasks/main.yml
+++ b/packer-rocm/playbooks/roles/tuned_profile/tasks/main.yml
@@ -1,0 +1,120 @@
+---
+
+- name: Preparation block
+  when: prep_facts is not defined
+  block:  # skip considerable work if this role is applied multiple times in a play
+
+    - name: Ensure 'tuned' is installed
+      ansible.builtin.package:
+        name: tuned
+        state: present
+      become: true
+
+    - name: Ensure dynamic tuning is disabled
+      become: true
+      ansible.builtin.lineinfile:
+        path: "{{ tuned_main_config }}"
+        line: 'dynamic_tuning = 0'
+        regexp: '^dynamic_tuning.*='
+      notify: tuned_restart
+
+    - name: Ensure 'tuned' is enabled/running
+      become: true
+      ansible.builtin.service:
+        name: tuned
+        state: started
+        enabled: true
+
+    - name: Ensure '/etc/ansible/facts.d'
+      become: true
+      ansible.builtin.file:
+        state: directory
+        path: /etc/ansible/facts.d
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Ensure custom facts for 'tuned'
+      become: true
+      ansible.builtin.copy:
+        src: tuned.fact
+        dest: /etc/ansible/facts.d/tuned.fact
+        owner: root
+        group: root
+        mode: '0755'  # must be executable for all users
+      notify: ansible_setup  # if this role is run before others, re-read facts for their benefit w/ handler
+
+    # this tasks exists because 'tuned' constants point here on Ubuntu 22.04, yet non-existent:
+    #   $ grep CFG_FILES /usr/lib/python3/dist-packages/tuned/consts.py
+    #   GRUB2_CFG_FILES = ["/etc/grub2.cfg", "/etc/grub2-efi.cfg"]
+    - name: Ensure links for bootloader plugin (Ubuntu 22 only)
+      become: true
+      when:
+        - ansible_distribution == 'Ubuntu'
+        - (ansible_distribution_major_version | int) == 22
+      ansible.builtin.file:
+        dest: "{{ grubcfg }}"
+        src: ../boot/grub/grub.cfg
+        owner: root
+        group: root
+        state: link
+      loop:
+        - /etc/grub2-efi.cfg
+        - /etc/grub2.cfg
+      loop_control:
+        loop_var: grubcfg
+    # without, the 'bootloader' plugin is effectively broken!
+    # Debian has addressed this; Ubuntu/Canonical picked it up in 24.04.
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+      register: prep_facts
+
+# per-profile tasks follow
+
+- name: "Make directory for '{{ tuned_profile_name }}'"
+  become: true
+  ansible.builtin.file:
+    path: "{{ (tuned_profile_basedir, tuned_profile_name) | path_join }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Copy supporting scripts
+  become: true
+  ansible.builtin.copy:
+    src: "{{ script }}"
+    dest: "{{ (tuned_profile_basedir, tuned_profile_name, script) | path_join }}"
+    mode: "0744"
+    owner: root
+    group: root
+  loop: "{{ tuned_profile_scripts }}"
+  loop_control:
+    loop_var: script
+
+- name: "Render '{{ tuned_profile_name }}'"
+  become: true
+  ansible.builtin.template:
+    src: tuned_profile.j2
+    dest: "{{ (tuned_profile_basedir, tuned_profile_name, 'tuned.conf') | path_join }}"
+    mode: '0644'
+    owner: root
+    group: root
+  notify: tuned_restart
+
+- name: Clear pending handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: "Enable '{{ tuned_profile_name }}'"
+  become: true
+  ansible.builtin.command: "tuned-adm profile {{ tuned_profile_name }}"
+  changed_when: "ansible_local['tuned']['selected_profile'] != tuned_profile_name"  # always try to set; report change based on prior facts
+  register: tunedadm
+  when: tuned_profile_enable is truthy(convert_bool=True)
+  notify: tuned_handler_reboot
+
+# preserve 'atomicity' of the role
+# if rebooting (not the default), do so *as part of the role* -- not at the end of the play
+- name: Flush reboot/wait handlers
+  ansible.builtin.meta: flush_handlers

--- a/packer-rocm/playbooks/roles/tuned_profile/templates/tuned_profile.j2
+++ b/packer-rocm/playbooks/roles/tuned_profile/templates/tuned_profile.j2
@@ -1,0 +1,10 @@
+{# template file for 'tuned.conf' profiles / the 'tuned_profile' role #}
+{{ ansible_managed | comment }}
+
+{% for section in tuned_profile_params | dict2items %}
+[{{ section.key }}]
+{% for param in section.value | dict2items %}
+{{ param.key }}={{ param.value }}
+{% endfor %}
+
+{% endfor %}

--- a/packer-rocm/playbooks/tuned.yml
+++ b/packer-rocm/playbooks/tuned.yml
@@ -16,11 +16,12 @@
         main:
           description: "Ansible managed; do not edit. Please 'include'/extend in other profiles instead."
           summary: 'AMD site customizations'
-          include: 'network-throughput'  # base profile to build ours upon
+          include: 'network-throughput'  # package/distribution-provided profile to build ours upon
         bootloader:  # one of many plugins; shouldn't be repeated. the 'cmdline_...' keys should be globally unique
           cmdline_amdsre_debug: 'earlyprintk=ttyS1,keep'
           cmdline_amdsre_iommu: 'amd_iommu=on iommu=pt nokaslr'
-          cmdline_amdsre_pci: 'pci=realloc=off pcie_aspm=off'  # opting out of power management may help avoid NVMe dropping out
+          cmdline_amdsre_pci: 'pci=realloc=off pcie_aspm=off'
+          cmdline_amdsre_perf_security: 'msr.allow_writes=on'
           # cmdline_amdsre_amdgpu: 'modprobe.blacklist=amdgpu amdgpu.noretry=1'
         disableacs:  # scripts may get their own section names to avoid repeat limitations
           type: script

--- a/packer-rocm/playbooks/tuned.yml
+++ b/packer-rocm/playbooks/tuned.yml
@@ -1,0 +1,35 @@
+---
+# yamllint disable rule:line-length
+- name: "Prepare 'tuned' service+profile"
+  hosts: default
+  environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
+    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
+    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
+  roles:
+    - name: Include 'tuned' Role
+      role: tuned_profile
+      tuned_profile_name: amd_custom
+      tuned_profile_scripts:
+        - acs_disable.sh
+      tuned_profile_params:
+        main:
+          description: "Ansible managed; do not edit. Please 'include'/extend in other profiles instead."
+          summary: 'AMD site customizations'
+          include: 'network-throughput'  # base profile to build ours upon
+        bootloader:  # one of many plugins; shouldn't be repeated. the 'cmdline_...' keys should be globally unique
+          cmdline_amdsre_debug: 'earlyprintk=ttyS1,keep'
+          cmdline_amdsre_iommu: 'amd_iommu=on iommu=pt nokaslr'
+          cmdline_amdsre_pci: 'pci=realloc=off pcie_aspm=off'  # opting out of power management may help avoid NVMe dropping out
+          # cmdline_amdsre_amdgpu: 'modprobe.blacklist=amdgpu amdgpu.noretry=1'
+        disableacs:  # scripts may get their own section names to avoid repeat limitations
+          type: script
+          script: '${i:PROFILE_DIR}/acs_disable.sh'
+        sysctl:
+          kernel.numa_balancing: 0
+          dev.raid.speed_limit_min: 100000
+          dev.raid.speed_limit_max: 20000000
+        variables:  # file not managed by the role, not yet implemented/read. planned for (out-of-band) edits/to be shared among profiles
+          include: /etc/tuned/amd-vars.conf
+
+# vim: ft=yaml.ansible

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -61,6 +61,16 @@ build {
     ]
   }
 
+  provisioner "ansible" {
+    playbook_file = "${path.root}/../playbooks/tuned.yml"
+    user          = "ubuntu"
+    ansible_env_vars  = ["http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}"]
+    extra_arguments = [  
+      "-e", "ansible_python_interpreter=/usr/bin/python3",
+      "--scp-extra-args", "'-O'"
+    ]
+  }
+
   provisioner "shell" {
     execute_command   = "{{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
     scripts           = ["${path.root}/scripts/cleanup.sh"]


### PR DESCRIPTION
Porting over our `tuned_profile` role and some common parameters