### PR TITLE
Add Grafana dashboard

### DIFF
--- a/redfish-exporter/.env
+++ b/redfish-exporter/.env
@@ -33,6 +33,11 @@ SUBSCRIPTION_PAYLOAD="{ \
     \"Context\": \"YourContextData\" \
 }"
 
+# Config for setting default labels in Prometheus counter metrics.
+PROMETHEUS_CONFIG="{ \
+    \"Severity\": [\"Fatal\", \"Critical\", \"Informational\"] \
+}"
+
 REDFISH_SERVERS="[ \
-    {\"ip\": \"http://localhost:8000\", \"username\": \"Username1\", \"password\": \"Password1\", \"loginType\": \"Session\", \"slurmNode\": \"Node1\"}
+    {\"ip\": \"http://127.0.0.1:8000\", \"username\": \"Username1\", \"password\": \"Password1\", \"loginType\": \"Session\", \"slurmNode\": \"Node1\"}
 ]"

--- a/redfish-exporter/grafana_dashboard.json
+++ b/redfish-exporter/grafana_dashboard.json
@@ -1,0 +1,391 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Fatal\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Fatal",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Critical\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Critical",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Informational\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Informational",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hideTimeOverride": false,
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "round(sum by(Severity) (increase(RedFishEvents_received[$__range])))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "timeFrom": "24h",
+      "title": "Alert Histogram",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Fremont",
+  "uid": "fe0fxrzfjyf40f",
+  "version": 36,
+  "weekStart": ""
+}

--- a/redfish-exporter/k8s/exporter-configmap.yaml
+++ b/redfish-exporter/k8s/exporter-configmap.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: redfish-exporter-configmap
 data:
+# The Kubernetes DNS resolves the service name to an IP address
+# Which prevents the initial Prometheus counter from being initialized with correct label
+# See: https://github.com/nod-ai/ADA/pull/33
   redfish-servers: '[{"ip": "http://redfish-mock.silo.svc.cluster.local:8000", "username": "Username1", "password": "Password1", "loginType": "Session", "slurmNode": "Node1"}]'
   subscription-payload: |
     {

--- a/redfish-exporter/main.go
+++ b/redfish-exporter/main.go
@@ -97,7 +97,7 @@ func main() {
 	}()
 
 	// Initialize Prometheus metrics with default values
-	initializeMetrics(AppConfig.RedfishServers, AppConfig.PrometheusConfig.Severity)
+	initMetrics(AppConfig.RedfishServers, AppConfig.PrometheusConfig.Severity)
 
 	// Wait for shutdown signal
 	<-sigChan
@@ -120,20 +120,26 @@ func main() {
 	log.Println("Shutdown complete")
 }
 
-func initializeMetrics(redfishServers []RedfishServer, severities []string) {
+func initMetrics(redfishServers []RedfishServer, severities []string) {
 	for _, server := range redfishServers {
-		// Trim URL prefixes and extract the host
-		host := strings.TrimPrefix(strings.TrimPrefix(server.IP, "http://"), "https://")
-
-		// Trim the port if available
-		splitHost, _, err := net.SplitHostPort(host)
-		if err == nil {
-			host = splitHost
-		}
+		host := extractHost(server.IP)
 
 		// Initialize counters for each severity label
+		// Additional label combinations should be defined here
 		for _, severity := range severities {
 			metrics.EventCountMetric.WithLabelValues(host, severity).Add(0)
 		}
 	}
+}
+
+// Helper function to extract the host from the URL
+func extractHost(url string) string {
+	// Remove http:// or https://
+	host := strings.TrimPrefix(strings.TrimPrefix(url, "http://"), "https://")
+
+	// Trim the port if available
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	return host
 }


### PR DESCRIPTION
Add a Grafana dashboard JSON template to visualize the data.
![image](https://github.com/user-attachments/assets/e55d1af9-34b7-4607-8b2a-e0d279c5deed)

Add Prometheus initializer:
- Add default labels to init counters
- Match host label with received IP from event

Resolve an issue with Prometheus counters not being initialized (By Prometheus design) thus the first event is always being ignored:
https://github.com/prometheus/prometheus/issues/1673


