### PR TITLE
packer-rocm/os+udev: set 'NAME_KERNEL' RDMA rename mode

### DIFF
--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -16,7 +16,10 @@
         path: /etc/udev/rules.d/60-rdma-persistent-naming.rules
         regexp: '^ACTION=="add", SUBSYSTEM=="infiniband",.* PROGRAM="rdma_rename'
         line: >-
-          ACTION=="add", SUBSYSTEM=="infiniband", KERNEL!="hfi1*", PROGRAM="rdma_rename %k {{ os_rdma_rename_mode }}"
+          ACTION=="add",
+          SUBSYSTEM=="infiniband",
+          KERNEL!="hfi1*",
+          PROGRAM="rdma_rename %k {{ os_rdma_rename_mode }}"
         create: true
         owner: root
         group: root

--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -1,0 +1,27 @@
+---
+# vim: ft=yaml.ansible
+- name: OS Preparation  # the Packer 'file' provisioner runs this before other plays
+  gather_facts: false
+  hosts: default
+  become: true
+  environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
+    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
+    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
+    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
+  vars:  # change these with '-e var=...'
+    os_rdma: true  # accepts loosely 'true' or 'false' values. ie: 0, 1, yes, no
+    os_rdma_rename_mode: 'NAME_KERNEL'
+  tasks:
+
+    - name: "Manage RDMA device rename mode ({{ os_rdma_rename_mode }})"
+      when: os_rdma is truthy(convert_bool=True)
+      ansible.builtin.lineinfile:
+        # placing this in '/etc' precedes '/usr' or '/lib', overriding packages/enduring updates; see 'man 7 udev'
+        path: /etc/udev/rules.d/60-rdma-persistent-naming.rules
+        regexp: '^ACTION=="add", SUBSYSTEM=="infiniband",.* PROGRAM="rdma_rename'
+        line: |
+          ACTION=="add", SUBSYSTEM=="infiniband", KERNEL!="hfi1*", PROGRAM="rdma_rename %k {{ os_rdma_rename_mode }}"
+        create: true
+        owner: root
+        group: root
+        mode: '0644'

--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -15,7 +15,7 @@
         # placing this in '/etc' precedes '/usr' or '/lib', overriding packages/enduring updates; see 'man 7 udev'
         path: /etc/udev/rules.d/60-rdma-persistent-naming.rules
         regexp: '^ACTION=="add", SUBSYSTEM=="infiniband",.* PROGRAM="rdma_rename'
-        line: |
+        line: >-
           ACTION=="add", SUBSYSTEM=="infiniband", KERNEL!="hfi1*", PROGRAM="rdma_rename %k {{ os_rdma_rename_mode }}"
         create: true
         owner: root

--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -5,12 +5,12 @@
   hosts: default
   become: true
   vars:  # change these with '-e var=...'
-    os_rdma: true  # accepts loosely 'true' or 'false' values. ie: 0, 1, yes, no
+    os_rdma_rename: true  # accepts loosely 'true' or 'false' values. ie: 0, 1, yes, no
     os_rdma_rename_mode: 'NAME_KERNEL'
   tasks:
 
     - name: "Manage RDMA device rename mode ({{ os_rdma_rename_mode }})"
-      when: os_rdma is truthy(convert_bool=True)
+      when: os_rdma_rename is truthy(convert_bool=True)
       ansible.builtin.lineinfile:
         # placing this in '/etc' precedes '/usr' or '/lib', overriding packages/enduring updates; see 'man 7 udev'
         path: /etc/udev/rules.d/60-rdma-persistent-naming.rules

--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -4,10 +4,6 @@
   gather_facts: false
   hosts: default
   become: true
-  environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
-    http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
-    https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
-    no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
   vars:  # change these with '-e var=...'
     os_rdma: true  # accepts loosely 'true' or 'false' values. ie: 0, 1, yes, no
     os_rdma_rename_mode: 'NAME_KERNEL'

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -59,11 +59,21 @@ build {
   }
 
   provisioner "ansible" {
-    playbook_file = "${path.root}/../playbooks/rocm.yml"
+    playbook_file = "${path.root}/../playbooks/os_prep.yml"
     user          = "ubuntu"
     ansible_env_vars  = ["http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}"]
     extra_arguments = [
       "-e", "ansible_python_interpreter=/usr/bin/python3",  # work around Packer/SSH proxy+client limitations
+      "--scp-extra-args", "'-O'"
+    ]
+  }
+
+  provisioner "ansible" {
+    playbook_file = "${path.root}/../playbooks/rocm.yml"
+    user          = "ubuntu"
+    ansible_env_vars  = ["http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}"]
+    extra_arguments = [
+      "-e", "ansible_python_interpreter=/usr/bin/python3",
       "--scp-extra-args", "'-O'",
       "-e", "rocm_releases=${var.rocm_releases}",  # pass ROCm requests [release + packages]
       "-e", "rocm_extras=${var.rocm_extras}",


### PR DESCRIPTION
Certain packages on certain distributions provide `udev` rules that assume RDMA devices should have the `NAME_FALLBACK` mode:

> NAME_FALLBACK - Try to name devices in the following order:
>                by->onboard -> by-pci -> by-guid -> kernel

reference: https://github.com/linux-rdma/rdma-core/blob/master/kernel-boot/rdma_rename.c#L22

This play defaults to `NAME_KERNEL` instead:

> NAME_KERNEL - leave name as kernel provided

Why? Determinism. The kernel is a property chosen _(determined)_ as part of the deployment, and consequently, the name.

The playbook accepts variables, but these are not exposed to Packer. May be used elsewhere