### PR TITLE
packer-rocm/disk/vars: drop LVM, 'cloud-init' limitation. add vars

### DIFF
--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -40,6 +40,9 @@
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
+          -var rocm_builder_disk_format={{ rocm_builder_disk_format | default('raw') }}
+          -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}
+          -var rocm_builder_memory={{ rocm_builder_memory | default(4096) }}
           -var rocm_installed={{ rocm_installed | default('false') }}
           -var niccli_wanted={{ niccli_wanted | default('true') }}
           -var niccli_driver={{ niccli_driver | default('true') }}

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -40,7 +40,6 @@
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
-          -var rocm_builder_disk_format={{ rocm_builder_disk_format | default('raw') }}
           -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}
           -var rocm_builder_memory={{ rocm_builder_memory | default(4096) }}
           -var rocm_installed={{ rocm_installed | default('false') }}

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "rocm" {
   boot_wait       = "5s"
   efi_boot        = true
   efi_drop_efivars = true  # don't place efivars.fd in output artifact
-  format          = var.rocm_builder_disk_format
+  format          = "raw"  # QCOW may not be converted
   headless        = var.headless
   http_directory  = var.http_directory
   shutdown_command       = "sudo -S shutdown -P now"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "rocm" {
   boot_wait       = "5s"
   efi_boot        = true
   efi_drop_efivars = true  # don't place efivars.fd in output artifact
-  format          = "raw"  # QCOW may not be converted
+  format          = "raw"  # qcow2 may not be converted. if written to drives, can't be read back/won't find 'curtin'
   headless        = var.headless
   http_directory  = var.http_directory
   shutdown_command       = "sudo -S shutdown -P now"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -42,7 +42,7 @@ build {
     sources     = [
       "${path.root}/scripts/curtin-hooks",
       "${path.root}/scripts/setup-bootloader",
-      "${path.root}/scripts/install-custom-package"
+      "${path.root}/scripts/install-custom-packages"
     ]  # last script only copied to allow 'curtin.sh'/hooks to be satisfied
   }
 

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -10,9 +10,9 @@ source "qemu" "rocm" {
   }
   cd_label        = "cidata"
   # system resources
-  cpus            = rocm_builder_cpus
+  cpus            = var.rocm_builder_cpus
   disk_size       = "${var.rocm_builder_disk}"  # Packer seems to have trouble with strings that begin with numbers; explicitly cast
-  memory          = rocm_builder_memory
+  memory          = var.rocm_builder_memory
   # image/build prefs
   accelerator     = "kvm"  # or 'none' if KVM is unavailable
   boot_command    = ["<wait5>e<wait2>", "<down><down><down><end><wait>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -10,16 +10,16 @@ source "qemu" "rocm" {
   }
   cd_label        = "cidata"
   # system resources
-  cpus            = 8      # expedite compiling, adjust to machine allowance
-  disk_size       = "${var.rocm_builder_disk}"
-  memory          = 4096   # OOM w/ 2G during DKMS builds, 3G *may* suffice
+  cpus            = rocm_builder_cpus
+  disk_size       = "${var.rocm_builder_disk}"  # Packer seems to have trouble with strings that begin with numbers; explicitly cast
+  memory          = rocm_builder_memory
   # image/build prefs
   accelerator     = "kvm"  # or 'none' if KVM is unavailable
   boot_command    = ["<wait5>e<wait2>", "<down><down><down><end><wait>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
   boot_wait       = "5s"
   efi_boot        = true
   efi_drop_efivars = true  # don't place efivars.fd in output artifact
-  format          = "raw"
+  format          = var.rocm_builder_disk_format
   headless        = var.headless
   http_directory  = var.http_directory
   shutdown_command       = "sudo -S shutdown -P now"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -42,7 +42,8 @@ build {
     sources     = [
       "${path.root}/scripts/curtin-hooks",
       "${path.root}/scripts/setup-bootloader",
-      "${path.root}/scripts/install-custom-package"  # last script only copied to allow 'curtin.sh'/hooks to be satisfied.
+      "${path.root}/scripts/install-custom-package"
+    ]  # last script only copied to allow 'curtin.sh'/hooks to be satisfied
   }
 
   # docs suggest destination be made first with 'shell' when copying directories to avoid non-determinism

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -36,6 +36,15 @@ source "qemu" "rocm" {
 build {
   sources = ["source.qemu.rocm"]
 
+  # 'tgz' of custom packages not copied or managed with Makefile. instead: copied by 'file' Packer provisioner, processed by Ansible
+  provisioner "file" {
+    destination = "/tmp/"
+    sources     = [
+      "${path.root}/scripts/curtin-hooks",
+      "${path.root}/scripts/setup-bootloader",
+      "${path.root}/scripts/install-custom-package"  # last script only copied to allow 'curtin.sh'/hooks to be satisfied.
+  }
+
   # docs suggest destination be made first with 'shell' when copying directories to avoid non-determinism
   provisioner "shell" {
     inline = ["mkdir /tmp/packer-pkgs"]
@@ -44,11 +53,6 @@ build {
   provisioner "file" {
     destination = "/tmp/packer-pkgs"
     source = "${path.root}/../packages/"
-  }
-
-  provisioner "file" {
-    destination = "/tmp/curtin-hooks"
-    source      = "${path.root}/scripts/curtin-hooks"
   }
 
   provisioner "shell" {

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -39,12 +39,6 @@ variable "rocm_builder_disk" {
   description = "amdgpu and ROCm releases demand considerable space. Layout in 'user-data-rocm' will claim all of this"
 }
 
-variable "rocm_builder_disk_format" {
-  type = string
-  default = "raw"
-  description = "Virtual Machine disk format: ['raw', 'qcow2']"
-}
-
 variable "niccli_wanted" {
   type = string
   default = "true"

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -21,10 +21,28 @@ variable "rocm_extras" {
   description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]"
 }
 
+variable "rocm_builder_cpus" {
+  type = number
+  default = 4
+  description = "Number of CPU threads given to the builder Virtual Machine. More may help compilation speed"
+}
+
+variable "rocm_builder_memory" {
+  type = number
+  default = 4096
+  description = "RAM given to the builder VM, measured in MB. Out-of-memory conditions were found with 2G during DKMS builds"
+}
+
 variable "rocm_builder_disk" {
   type = string
   default = "70G"
   description = "amdgpu and ROCm releases demand considerable space. Layout in 'user-data-rocm' will claim all of this"
+}
+
+variable "rocm_builder_disk_format" {
+  type = string
+  default = "raw"
+  description = "Virtual Machine disk format: ['raw', 'qcow2']"
 }
 
 variable "niccli_wanted" {

--- a/packer-rocm/ubuntu/user-data-rocm
+++ b/packer-rocm/ubuntu/user-data-rocm
@@ -56,8 +56,9 @@ autoinstall:
     swap:
       size: 0
     layout:
-      name: lvm
-      # if 'sizing-policy' is 'scaled', 'disk_size' in 'ubuntu-rocm.pkr.hcl' must account for only 50% availability. compilation demands considerable space
+      # 'cloud-init'/cc_growpart don't handle common LVM well, so direct partitions
+      # cc_growpart.py[DEBUG]: '/' SKIPPED: Resizing mapped device (/dev/mapper/ubuntu--vg-ubuntu--lv) skipped as it is not encrypted.
+      name: direct
       sizing-policy: all
       # reset-partition: true  # likely impractical with ROCm/amdgpu/etc, multiplies usage
   late-commands:


### PR DESCRIPTION
Found that `cloud-init` has trouble extending LVM to fill storage, see below. Instead of working around this... fall back to partitions.

Secondarily: parameters controlling resources for the builder have been added.
```
/var/log/cloud-init.log:2024-10-11 22:10:06,904 - cc_growpart.py[DEBUG]: '/' SKIPPED: Resizing mapped device (/dev/mapper/ubuntu--vg-ubuntu--lv) skipped as it is not encrypted.
```