### PR TITLE
packer-rocm/LVM-dropfix: add post-processor for 'flat'/tarball creation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "amdchecknode"]
+	path = amdchecknode
+	url = https://github.com/joelandman-amd/amdchecknode.git

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -69,9 +69,6 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
 ### I/O
 
-The artifact is named `ubuntu-rocm.tar.gz`. When building with `ansible-pull`, it may be here:  
-`~/.ansible/pull/$HOSTNAME/packer-rocm/packer-maas/ubuntu`
-
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
 | `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | _6.2.2_ |
@@ -97,6 +94,9 @@ maas admin boot-resources create \
      filetype='tgz' \
      content@=ubuntu-rocm.tar.gz
 ```
+
+The artifact is named `ubuntu-rocm.tar.gz`. When building with `ansible-pull`, it may be here:  
+`~/.ansible/pull/$HOSTNAME/packer-rocm/packer-maas/ubuntu`
 
 #### Proxy
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -12,8 +12,7 @@ project.
 
 * [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
-* `qemu`, `qemu-nbd`
-* `FUSE` _(Filesystem in Userspace)_
+* `qemu`, `qemu-nbd`, `nbd-fuse`, `fuse`
 * `xorriso` or `genisoimage`
 * `rsync`
 * `git`

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -12,7 +12,8 @@ project.
 
 * [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
-* `qemu`, `qemu-nbd`, `nbd-fuse`, `fuse`
+* `qemu`, `qemu-nbd`, `nbd-fuse`, `fuse`, `nbdkit`
+* `nbdkit-{nbd-plugin,plugin-nbd}` _(Fedora/Debian, respectively)_
 * `xorriso` or `genisoimage`
 * `rsync`
 * `git`

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -12,7 +12,8 @@ project.
 
 * [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
-* `qemu`
+* `qemu`, `qemu-nbd`
+* `FUSE` _(Filesystem in Userspace)_
 * `xorriso` or `genisoimage`
 * `rsync`
 * `git`
@@ -68,7 +69,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
 ### I/O
 
-The artifact is named `ubuntu-rocm.dd.gz`. When building with `ansible-pull`, it may be here:  
+The artifact is named `ubuntu-rocm.tar.gz`. When building with `ansible-pull`, it may be here:  
 `~/.ansible/pull/$HOSTNAME/packer-rocm/packer-maas/ubuntu`
 
 | Variable | Description | Default |
@@ -83,6 +84,19 @@ The artifact is named `ubuntu-rocm.dd.gz`. When building with `ansible-pull`, it
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
 | `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-generic`<br />_Manual:_ None |
+
+#### MaaS
+
+This image is built _(and uploaded)_ in `tgz` format to respect customized disk layouts:
+
+```shell
+maas admin boot-resources create \
+     name='custom/packer-rocm-ubuntu-22.04.5' \
+     title='packer-rocm (Ubuntu 22.04.5)' \
+     architecture='amd64/generic' \
+     filetype='tgz' \
+     content@=ubuntu-rocm.tar.gz
+```
 
 #### Proxy
 

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -15,7 +15,7 @@
           ansible.builtin.git:
             repo: "https://github.com/canonical/packer-maas.git"
             dest: "{{ packer_maas_dir }}"
-            version: "{{ packer_maas_tag | default('v1.2.0') }}"
+            version: "{{ packer_maas_tag | default('9046979a9e92bb0303ef47da180b0af29f03332f') }}"  # current latest (1.2.0) lacks several relevant fixes, default to known commit
 
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -40,6 +40,8 @@
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
+          -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}
+          -var rocm_builder_memory={{ rocm_builder_memory | default(4096) }}
           -var rocm_installed={{ rocm_installed | default('false') }}
           -var niccli_wanted={{ niccli_wanted | default('true') }}
           -var niccli_driver={{ niccli_driver | default('true') }}

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -15,7 +15,7 @@
           ansible.builtin.git:
             repo: "https://github.com/canonical/packer-maas.git"
             dest: "{{ packer_maas_dir }}"
-            version: "{{ packer_maas_tag | default('9046979a9e92bb0303ef47da180b0af29f03332f') }}"  # current latest (1.2.0) lacks several relevant fixes, default to known commit
+            version: "{{ packer_maas_tag | default('9046979a9e92bb0303ef47da180b0af29f03332f') }}"  # current latest ('v1.2.0') lacks several relevant fixes, default to known commit
 
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -143,7 +143,7 @@ build {
       "SOURCE=${source.name}",
       "OUTPUT=${var.rocm_filename}",
       "IMG_FMT=raw",
-      "ROOT_PARTITION=2",
+      "ROOT_PARTITION=3",
       "source ../scripts/fuse-nbd",
       "source ../scripts/fuse-tar-root",
       "rm -rf output-${source.name}"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -140,7 +140,7 @@ build {
 
   post-processor "shell-local" {
     inline = [
-      "SOURCE=flat",
+      "SOURCE=rocm",  # reflects the name assigned to the build source
       "IMG_FMT=raw",
       "ROOT_PARTITION=2",
       "OUTPUT=ubuntu-rocm.tar.gz",

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -138,7 +138,15 @@ build {
     ]
   }
 
-  post-processor "compress" {
-    output = "ubuntu-rocm.dd.gz"
+  post-processor "shell-local" {
+    inline = [
+      "SOURCE=flat",
+      "IMG_FMT=raw",
+      "ROOT_PARTITION=2",
+      "OUTPUT=ubuntu-rocm.tar.gz",
+      "source ../scripts/fuse-nbd",
+      "source ../scripts/fuse-tar-root"
+    ]
+    inline_shebang = "/bin/bash -e"
   }
 }

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -140,12 +140,13 @@ build {
 
   post-processor "shell-local" {
     inline = [
-      "SOURCE=rocm",  # reflects the name assigned to the build source
+      "SOURCE=${source.name}",
+      "OUTPUT=${var.rocm_filename}",
       "IMG_FMT=raw",
       "ROOT_PARTITION=2",
-      "OUTPUT=ubuntu-rocm.tar.gz",
       "source ../scripts/fuse-nbd",
-      "source ../scripts/fuse-tar-root"
+      "source ../scripts/fuse-tar-root",
+      "rm -rf output-${source.name}"
     ]
     inline_shebang = "/bin/bash -e"
   }

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -3,6 +3,12 @@ variable "ubuntu_release" {
   default = "22.04.5"
 }
 
+variable "rocm_filename" {
+  type        = string
+  default     = "ubuntu-rocm.tar.gz"
+  description = "The name of the output file/artifact (tarball)"
+}
+
 variable "rocm_releases" {
   type = string
   default = "6.2.2"

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -27,6 +27,18 @@ variable "rocm_extras" {
   description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]"
 }
 
+variable "rocm_builder_cpus" {
+  type = number
+  default = 4
+  description = "Number of CPU threads given to the builder Virtual Machine. More may help compilation speed"
+}
+
+variable "rocm_builder_memory" {
+  type = number
+  default = 4096
+  description = "RAM given to the builder VM, measured in MB. Out-of-memory conditions were found with 2G during DKMS builds"
+}
+
 variable "rocm_builder_disk" {
   type = string
   default = "70G"

--- a/packer-rocm/ubuntu/user-data-rocm
+++ b/packer-rocm/ubuntu/user-data-rocm
@@ -56,8 +56,9 @@ autoinstall:
     swap:
       size: 0
     layout:
-      name: lvm
-      # if 'sizing-policy' is 'scaled', 'disk_size' in 'ubuntu-rocm.pkr.hcl' must account for only 50% availability. compilation demands considerable space
+      # 'cloud-init'/cc_growpart don't handle common LVM well, so direct partitions
+      # cc_growpart.py[DEBUG]: '/' SKIPPED: Resizing mapped device (/dev/mapper/ubuntu--vg-ubuntu--lv) skipped as it is not encrypted.
+      name: direct
       sizing-policy: all
       # reset-partition: true  # likely impractical with ROCm/amdgpu/etc, multiplies usage
   late-commands:

--- a/redfish-exporter/.env
+++ b/redfish-exporter/.env
@@ -33,6 +33,11 @@ SUBSCRIPTION_PAYLOAD="{ \
     \"Context\": \"YourContextData\" \
 }"
 
+# Config for setting default labels in Prometheus counter metrics.
+PROMETHEUS_CONFIG="{ \
+    \"Severity\": [\"Fatal\", \"Critical\", \"Informational\"] \
+}"
+
 REDFISH_SERVERS="[ \
-    {\"ip\": \"http://localhost:8000\", \"username\": \"Username1\", \"password\": \"Password1\", \"loginType\": \"Session\", \"slurmNode\": \"Node1\"}
+    {\"ip\": \"http://127.0.0.1:8000\", \"username\": \"Username1\", \"password\": \"Password1\", \"loginType\": \"Session\", \"slurmNode\": \"Node1\"}
 ]"

--- a/redfish-exporter/.env
+++ b/redfish-exporter/.env
@@ -6,6 +6,7 @@ METRICS_PORT="2112"
 USE_SSL="false"
 CERTFILE="path/to/certfile"
 KEYFILE="path/to/keyfile"
+SLURM_USER="slurm user here"
 SLURM_TOKEN="token string here, from secret when for real"
 SLURM_CONTROL_NODE="slurm control node IP:Port"
 

--- a/redfish-exporter/README.md
+++ b/redfish-exporter/README.md
@@ -68,6 +68,7 @@ The AMD Redfish Exporter is configured using environment variables or a configur
 - `USE_SSL`: Enable SSL/TLS (default: "false")
 - `CERTFILE`: Path to SSL certificate file (required if USE_SSL is true)
 - `KEYFILE`: Path to SSL key file (required if USE_SSL is true)
+- `SLURM_USER`: SLURM user name
 - `SLURM_TOKEN`: SLURM authentication token
 - `SLURM_CONTROL_NODE`: SLURM control node address
 - `REDFISH_SERVERS`: JSON array of Redfish server configurations

--- a/redfish-exporter/config.go
+++ b/redfish-exporter/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	}
 	SlurmToken          string
 	SlurmControlNode    string
+	SlurmUser           string
 	SubscriptionPayload SubscriptionPayload
 	RedfishServers      []RedfishServer
 	TriggerEvents       []TriggerEvent
@@ -117,6 +118,7 @@ func setupConfig() Config {
 
 	AppConfig.SlurmToken = os.Getenv("SLURM_TOKEN")
 	AppConfig.SlurmControlNode = os.Getenv("SLURM_CONTROL_NODE")
+	AppConfig.SlurmUser = os.Getenv("SLURM_USER")
 
 	subscriptionPayloadJSON := os.Getenv("SUBSCRIPTION_PAYLOAD")
 	if err := json.Unmarshal([]byte(subscriptionPayloadJSON), &AppConfig.SubscriptionPayload); err != nil {

--- a/redfish-exporter/docs/configuration.md
+++ b/redfish-exporter/docs/configuration.md
@@ -12,6 +12,7 @@ The AMD Redfish Exporter can be configured using the following environment varia
 - `CERTFILE`: Path to SSL certificate file
 - `KEYFILE`: Path to SSL key file
 - `METRICS_PORT`: Port to expose Prometheus metrics (default: "2112")
+- `SLURM_USER`: SLURM user name
 - `SLURM_TOKEN`: SLURM authentication token
 - `SLURM_CONTROL_NODE`: SLURM control node address
 - `SUBSCRIPTION_PAYLOAD`: JSON string containing Redfish subscription details

--- a/redfish-exporter/grafana_dashboard.json
+++ b/redfish-exporter/grafana_dashboard.json
@@ -1,0 +1,391 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.2.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Fatal\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Fatal",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Critical\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Critical",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "round(sum(increase(RedFishEvents_received{Severity=\"Informational\"}[$__range])) by (Severity))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Informational",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hideTimeOverride": false,
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "round(sum by(Severity) (increase(RedFishEvents_received[$__range])))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "timeFrom": "24h",
+      "title": "Alert Histogram",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Fremont",
+  "uid": "fe0fxrzfjyf40f",
+  "version": 36,
+  "weekStart": ""
+}

--- a/redfish-exporter/k8s/exporter-configmap.yaml
+++ b/redfish-exporter/k8s/exporter-configmap.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: redfish-exporter-configmap
 data:
+# The Kubernetes DNS resolves the service name to an IP address
+# Which prevents the initial Prometheus counter from being initialized with correct label
+# See: https://github.com/nod-ai/ADA/pull/33
   redfish-servers: '[{"ip": "http://redfish-mock.silo.svc.cluster.local:8000", "username": "Username1", "password": "Password1", "loginType": "Session", "slurmNode": "Node1"}]'
   subscription-payload: |
     {

--- a/redfish-exporter/main.go
+++ b/redfish-exporter/main.go
@@ -59,7 +59,7 @@ func main() {
 		if len(strings.TrimSpace(AppConfig.SlurmControlNode)) == 0 {
 			log.Fatalf("Provide slurm control node IP:Port to enable slurm")
 		}
-		_, err := slurm.NewClient(AppConfig.SlurmControlNode, AppConfig.SlurmToken)
+		_, err := slurm.NewClient(AppConfig.SlurmControlNode, AppConfig.SlurmUser, AppConfig.SlurmToken)
 		if err != nil {
 			log.Fatalf("failed to create slurm client, err: %+v", err)
 		}

--- a/redfish-exporter/slurm/slurm.go
+++ b/redfish-exporter/slurm/slurm.go
@@ -54,11 +54,14 @@ type Client struct {
 
 var apiCl *Client // singleton client
 
-func NewClient(slurmControlNode, slurmToken string) (*Client, error) {
+func NewClient(slurmControlNode, slurmUser, slurmToken string) (*Client, error) {
 	slConfig := &SlurmServerConfig{
 		URL:         slurmControlNode,
 		Username:    defaultSlurmUsername,
 		BearerToken: slurmToken,
+	}
+	if slurmUser != "" {
+		slConfig.Username = slurmUser
 	}
 	cl := createRestClient(slConfig)
 	c := &Client{apiClient: cl}

--- a/slurm/README.md
+++ b/slurm/README.md
@@ -1,0 +1,53 @@
+# Ansible Slurm Installation
+
+## Purpose
+
+The purpose of these playbooks are to install a slurm cluster extracting information about the cluster makeup from the ansible inventory file.
+
+### Requirements
+
+* `ansible-core`, examples: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
+
+### Installation
+
+All of the relevant configuration data for the slurm cluster is either provided in the inventory file or it is provided in the files section of the slurm directory.
+
+The config files are:
+
+* cgroups.conf 
+* slurm.conf
+* slurmdbd.conf
+
+In addition to the config files the munge.key for the slurm nodes is placed into that directory.
+
+#### Example inventory.yml
+
+```yaml
+all:
+  children:
+    slurm_compute_nodes:
+      hosts:
+        ansible-test01:
+        ansible-test02:
+        ansible-test03:
+        ansible-test04:
+    slurm_head_node:
+      hosts:
+        ansible-test01:
+    slurmdbd_node:
+      hosts:
+        ansible-test01:
+  vars:
+    ansible_user: ubuntu
+    cluster_name: vlan3051
+    slurm_partition: test
+    slurm_config_file: /etc/slurm/slurm.conf
+    cgroup_config_file: /etc/slurm/cgroup.conf
+    munge_key_file: /etc/munge/munge.key
+```
+
+#### Running the playbook
+
+```shell
+ansible-playbook -i inventory.yml install_slurm_all.yml
+```


### PR DESCRIPTION
In #35 I aimed to drop LVM, return to plain disk images. This was mistaken. MaaS cannot find `/curtin` within. Images produced currently are unfit for purpose.

This _appears_ to be due to _partially_ following in the footsteps of `packer-maas`. The storage layout goes from `lvm` to `direct`, but I missed their post-processing.

With non-LVM images we can't just compress the image, apparently. MaaS wants those repacked as a tarball.

`packer-maas` 'flat' references:

- [user-data](https://github.com/canonical/packer-maas/blob/main/ubuntu/user-data-flat)
- [Packer HCL](https://github.com/canonical/packer-maas/blob/main/ubuntu/ubuntu-flat.pkr.hcl)

Context/differentiation, the LVM references:

- [user-data](https://github.com/canonical/packer-maas/blob/main/ubuntu/user-data-lvm)
- [Packer HCL](https://github.com/canonical/packer-maas/blob/main/ubuntu/ubuntu-lvm.pkr.hcl)