### PR TITLE
packer-rocm/post-processor: fixes

### DIFF
--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -148,7 +148,7 @@ build {
       "SOURCE=${source.name}",
       "OUTPUT=${var.rocm_filename}",
       "IMG_FMT=raw",
-      "ROOT_PARTITION=3",
+      "ROOT_PARTITION=2",
       "source ../scripts/fuse-nbd",
       "source ../scripts/fuse-tar-root",
       "rm -rf output-${source.name}"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -149,6 +149,14 @@ build {
       "OUTPUT=${var.rocm_filename}",
       "IMG_FMT=raw",
       "ROOT_PARTITION=2",
+      # expedite compression: use an exported function to test for 'pigz' and remap 'gzip' to it, if found
+      "if command -v pigz > /dev/null 2>&1; then",
+      "  echo 'Mapping gzip to pigz for parallel compression'",
+      "  gzip() { pigz \"$@\"; }",
+      "  export -f gzip",
+      "else",
+      "  echo '*Not* mapping gzip to pigz for parallel compression'",
+      "fi",
       "source ../scripts/fuse-nbd",
       "source ../scripts/fuse-tar-root",
       "rm -rf output-${source.name}"

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -139,9 +139,10 @@ build {
       "apt-get autoremove --purge -yq",
       "apt-get clean -yq",
       "cloud-init clean --logs --machine-id --configs all",
-      "rm -fv /etc/cloud/cloud.cfg.d/{*installer*,20-disable-cc-dpkg-grub}.cfg /etc/cloud/ds-identify.cfg",
-      "find /tmp/niccli -xdev -delete || true",
-      "find /tmp/libbnxt_re -xdev -delete || true",
+      "rm -fv /etc/ssh/ssh_host_* /etc/cloud/cloud.cfg.d/{*installer*,20-disable-cc-dpkg-grub}.cfg /etc/cloud/ds-identify.cfg /var/log/{alternatives,bootstrap}.log",
+      "find /tmp/niccli -xdev -delete",
+      "find /tmp/libbnxt_re -xdev -delete",
+      "find /var/log/installer -xdev -delete",
     ]
   }
 

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -140,6 +140,8 @@ build {
       "apt-get clean -yq",
       "cloud-init clean --logs --machine-id --configs all",
       "rm -fv /etc/cloud/cloud.cfg.d/{*installer*,20-disable-cc-dpkg-grub}.cfg /etc/cloud/ds-identify.cfg",
+      "find /tmp/niccli -xdev -delete || true",
+      "find /tmp/libbnxt_re -xdev -delete || true",
     ]
   }
 


### PR DESCRIPTION
More fixes following the LVM -> direct partition, 'raw image' -> tarball adjustments.

The partition index was wrong, I misunderstood the usage - changed it when the problem lied elsewhere _(missing some NBD/fuse dependencies)_. This undoes that, allowing the root partition to finally be found.

Upstream uses `gzip`, we can speed this up with `pigz` and an exported function _(aliases don't work for sourced files)_