### PR TITLE
packer-rocm/custom kernel: forward request, use script

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -62,7 +62,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     PACKER_LOG=1 packer build \
         -var kernel="linux-image-generic-hwe-22.04=5.15.*" \
         -var rocm_releases="6.2.2,6.2.1" \
-        -var rocm_extras="mesa-amdgpu-va-drivers,ansible" \
+        -var rocm_extras="mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*" \
         -var rocm_builder_disk="70G" \
         -only=qemu.rocm .
     ```

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -71,8 +71,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
-| `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | _6.2.2_ |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. | _mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*_ |
+| `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. | `mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*` |
 | `rocm_kernel` | The kernel package with an optional release specifier.<br/>Headers/others may be defined in `rocm_extras` | `linux-image-generic-hwe-22.04=5.15.*` |
 | `rocm_installed` | If _ROCm_ packages are installed. The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_disk` | Space given to the builder VM; releases compound quickly. | _70G_ |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -60,7 +60,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
     # Build
     PACKER_LOG=1 packer build \
-        -var kernel=linux-generic-hwe-22.04 \
+        -var kernel="linux-image-generic-hwe-22.04=5.15.*" \
         -var rocm_releases="6.2.2,6.2.1" \
         -var rocm_extras="mesa-amdgpu-va-drivers,ansible" \
         -var rocm_builder_disk="70G" \
@@ -80,7 +80,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 | `niccli_sum` | Optional, string. Checksum to use for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
-| `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-generic-hwe-22.04`<br />_Manual:_ None, deferred to MaaS |
+| `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-image-generic-hwe-22.04=5.15.*`<br />_Manual:_ None, deferred to MaaS |
 
 #### MaaS
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -60,7 +60,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
     # Build
     PACKER_LOG=1 packer build \
-        -var kernel=linux-hwe \
+        -var kernel=linux-generic-hwe-22.04 \
         -var rocm_releases="6.2.2,6.2.1" \
         -var rocm_extras="mesa-amdgpu-va-drivers,ansible" \
         -var rocm_builder_disk="70G" \
@@ -80,7 +80,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 | `niccli_sum` | Optional, string. Checksum to use for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
-| `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-hwe`<br />_Manual:_ None |
+| `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-generic-hwe-22.04`<br />_Manual:_ None, deferred to MaaS |
 
 #### MaaS
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -60,8 +60,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
     # Build
     PACKER_LOG=1 packer build \
-        -var kernel="linux-image-generic-hwe-22.04=5.15.*" \
         -var rocm_releases="6.2.2,6.2.1" \
+        -var rocm_kernel="linux-image-generic-hwe-22.04=5.15.*" \
         -var rocm_extras="mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*" \
         -var rocm_builder_disk="70G" \
         -only=qemu.rocm .

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -72,7 +72,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
 | `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | _6.2.2_ |
-| `rocm_extras` | Packages to install _after_ `amdgpu-dkms` and _ROCm_. Also comma-separated. | _mesa-amdgpu-va-drivers_ |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. | _mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*_ |
+| `rocm_kernel` | The kernel package with an optional release specifier.<br/>Headers/others may be defined in `rocm_extras` | `linux-image-generic-hwe-22.04=5.15.*` |
 | `rocm_installed` | If _ROCm_ packages are installed. The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_disk` | Space given to the builder VM; releases compound quickly. | _70G_ |
 | `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |
@@ -80,7 +81,6 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 | `niccli_sum` | Optional, string. Checksum to use for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
-| `kernel` | _MaaS_ images do not _typically_ include a kernel. Set this to include one. | _Ansible:_ `linux-image-generic-hwe-22.04=5.15.*`<br />_Manual:_ None, deferred to MaaS |
 
 #### MaaS
 

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -35,7 +35,7 @@
       ansible.builtin.command:  # TODO: improve command preparation, rely on Packer defaults [and avoid typing problems] when Ansible extra-vars are unspecified
         cmd: >
           packer build
-          -var kernel={{ kernel | default('linux-hwe') }}
+          -var kernel={{ kernel | default('linux-generic-hwe-22.04') }}
           -var headless={{ headless | default('true') }}
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -35,7 +35,7 @@
       ansible.builtin.command:  # TODO: improve command preparation, rely on Packer defaults [and avoid typing problems] when Ansible extra-vars are unspecified
         cmd: >
           packer build
-          -var kernel={{ kernel | default('linux-generic-hwe-22.04') }}
+          -var kernel={{ kernel | default('linux-image-generic-hwe-22.04=5.15.*') }}
           -var headless={{ headless | default('true') }}
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -37,7 +37,7 @@
           packer build
           -var kernel={{ kernel | default('linux-image-generic-hwe-22.04=5.15.*') }}
           -var headless={{ headless | default('true') }}
-          -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers') }}
+          -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
           -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -35,9 +35,9 @@
       ansible.builtin.command:  # TODO: improve command preparation, rely on Packer defaults [and avoid typing problems] when Ansible extra-vars are unspecified
         cmd: >
           packer build
-          -var kernel={{ kernel | default('linux-image-generic-hwe-22.04=5.15.*') }}
           -var headless={{ headless | default('true') }}
           -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*') }}
+          -var rocm_kernel={{ rocm_kernel | default('linux-image-generic-hwe-22.04=5.15.*') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
           -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}

--- a/packer-rocm/playbooks/rocm.yml
+++ b/packer-rocm/playbooks/rocm.yml
@@ -39,13 +39,6 @@
     rocm_fedora_el: '9.4'  # NOTE: placeholder, for testing: assume equivalence between this RHEL release and 'current Fedora'
   tasks:
 
-    - name: "Install any 'extra' packages before 'amdgpu-dkms' or ROCm"
-      ansible.builtin.package:
-        name: "{{ rocm_extras | split(',') }}"
-        state: present
-        update_cache: true
-      when: rocm_extras is defined
-
     - name: "Sort ROCm version requests"
       ansible.builtin.set_fact:
         rocm_release_peak: "{{ (rocm_requests | community.general.version_sort) | last }}"
@@ -123,6 +116,13 @@
             filename: rocm
           loop: "{{ rocm_requests }}"
           loop_control: { loop_var: rocm_release }
+
+    - name: "Install any 'extra' packages before 'amdgpu-dkms' or ROCm"
+      ansible.builtin.package:
+        name: "{{ rocm_extras | split(',') }}"
+        state: present
+        update_cache: true
+      when: rocm_extras is defined
 
     - name: "Install 'amdgpu-dkms'"
       ansible.builtin.package:

--- a/packer-rocm/playbooks/rocm.yml
+++ b/packer-rocm/playbooks/rocm.yml
@@ -39,6 +39,13 @@
     rocm_fedora_el: '9.4'  # NOTE: placeholder, for testing: assume equivalence between this RHEL release and 'current Fedora'
   tasks:
 
+    - name: "Install any 'extra' packages before 'amdgpu-dkms' or ROCm"
+      ansible.builtin.package:
+        name: "{{ rocm_extras | split(',') }}"
+        state: present
+        update_cache: true
+      when: rocm_extras is defined
+
     - name: "Sort ROCm version requests"
       ansible.builtin.set_fact:
         rocm_release_peak: "{{ (rocm_requests | community.general.version_sort) | last }}"
@@ -129,12 +136,5 @@
       loop: "{{ rocm_requests | community.general.version_sort }}"
       loop_control: { loop_var: _rel }
       when: rocm_installed is truthy(convert_bool=True)
-
-    - name: "Install remaining packages"
-      ansible.builtin.package:
-        name: "{{ rocm_extras | split(',') }}"
-        state: present
-        update_cache: true
-      when: rocm_extras is defined
 
 # vim: ft=yaml.ansible

--- a/packer-rocm/playbooks/roles/niccli/tasks/main.yml
+++ b/packer-rocm/playbooks/roles/niccli/tasks/main.yml
@@ -65,7 +65,7 @@
           - '*sles*'  # SUSE linux enterprise server
           - '*debug*'  # packages with debug symbols
 
-    - name: 'Install packages [found by OS family]'
+    - name: 'Install packages [found by OS family]'  # noqa: ignore-errors ('failed_when' hides context from output/logs; the choice to proceed with failure)
       become: true
       ansible.builtin.package:
         name: "{{ candidate if ansible_os_family in ['RedHat'] else omit }}"
@@ -75,6 +75,10 @@
       loop: "{{ (niccli_pkgs.files | map(attribute='path') | reject('search', 'aarch64')) | sort }}"
       # reject 'aarch64'; search can be greedy. Broadcom archives may repeat arch-free packages in arch-specific directories
       loop_control: { loop_var: candidate }
+      ignore_errors: "{{ 'netxtreme-peer-mem' in candidate }}"  # doesn't build against kernels with 'ib_peer_mem' mainlined
+      # TODO/consider:
+      # add block/recover, recovery task involves removing 'failed' packages. provides very clean DKMS tree
+      # may not be ideal for those who do wish to use 5.x kernels, requiring this
 
     # Looping installation above was found to be necessary due to the issues outlined here:
     #     https://github.com/ansible/ansible/issues/7513

--- a/packer-rocm/playbooks/roles/niccli/tasks/main.yml
+++ b/packer-rocm/playbooks/roles/niccli/tasks/main.yml
@@ -76,9 +76,6 @@
       # reject 'aarch64'; search can be greedy. Broadcom archives may repeat arch-free packages in arch-specific directories
       loop_control: { loop_var: candidate }
       ignore_errors: "{{ 'netxtreme-peer-mem' in candidate }}"  # doesn't build against kernels with 'ib_peer_mem' mainlined
-      # TODO/consider:
-      # add block/recover, recovery task involves removing 'failed' packages. provides very clean DKMS tree
-      # may not be ideal for those who do wish to use 5.x kernels, requiring this
 
     # Looping installation above was found to be necessary due to the issues outlined here:
     #     https://github.com/ansible/ansible/issues/7513

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -70,7 +70,7 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars  = ["HOME_DIR=/home/ubuntu", "http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}", "CLOUDIMG_CUSTOM_KERNEL=${var.kernel}", "DEBIAN_FRONTEND=noninteractive"]
+    environment_vars  = ["HOME_DIR=/home/ubuntu", "http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}", "CLOUDIMG_CUSTOM_KERNEL=${var.rocm_kernel}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command   = "{{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
     expect_disconnect = true
     scripts           = ["${path.root}/scripts/curtin.sh", "${path.root}/scripts/networking.sh", "${path.root}/scripts/cloudimg/install-custom-kernel.sh"]

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -70,10 +70,10 @@ build {
   }
 
   provisioner "shell" {
-    environment_vars  = ["HOME_DIR=/home/ubuntu", "http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}"]
+    environment_vars  = ["HOME_DIR=/home/ubuntu", "http_proxy=${var.http_proxy}", "https_proxy=${var.https_proxy}", "no_proxy=${var.no_proxy}", "CLOUDIMG_CUSTOM_KERNEL=${var.kernel}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command   = "{{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
     expect_disconnect = true
-    scripts           = ["${path.root}/scripts/curtin.sh", "${path.root}/scripts/networking.sh"]
+    scripts           = ["${path.root}/scripts/curtin.sh", "${path.root}/scripts/networking.sh", "${path.root}/scripts/cloudimg/install-custom-kernel.sh"]
   }
 
   provisioner "ansible" {
@@ -134,10 +134,12 @@ build {
   }
 
   provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive"
+    ]
     execute_command   = "{{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
     inline_shebang = "/bin/bash"  # not giving '-e'; allow clean-up drift - don't fail if a task fails
     inline = [
-      "export DEBIAN_FRONTEND=noninteractive",
       "apt-get autoremove --purge -yq",
       "apt-get clean -yq",
       "cloud-init clean --logs --machine-id --configs all",

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -9,6 +9,12 @@ variable "rocm_filename" {
   description = "The name of the output file/artifact (tarball)"
 }
 
+variable "rocm_kernel" {
+  type = string
+  default = "linux-image-generic-hwe-22.04=5.15.*"
+  description = "The kernel to include with the image. May include version specifier. Software will be compiled against this; define headers/others in 'rocm_extras'"
+}
+
 variable "rocm_releases" {
   type = string
   default = "6.2.2"

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -29,7 +29,7 @@ variable "rocm_installed" {
 
 variable "rocm_extras" {
   type = string
-  default = "mesa-amdgpu-va-drivers"
+  default = "mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*"
   description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]"
 }
 


### PR DESCRIPTION
The kernel requests have so far been ignored. The image lands with latest `linux-generic`, despite the fully-automated path preferring `linux-hwe`.

To handle this, adopt the `install--custom-kernel.sh` script from `packer-maas` and pass the variable along. The script will exit if unset.

Testing underway