### PR TITLE
packer-rocm/defaults: drop 5.15 specifier for HWE kernel, use 6.8

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -71,7 +71,7 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
-| `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
+| `rocm_releases` | One or more versions to include _[comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04` |
 | `rocm_installed` | If _ROCm_ packages are installed. The `amdgpu` _driver/extras_ are, always. | `False` |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -61,8 +61,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
     # Build
     PACKER_LOG=1 packer build \
         -var rocm_releases="6.2.2,6.2.1" \
-        -var rocm_kernel="linux-image-generic-hwe-22.04=5.15.*" \
-        -var rocm_extras="mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*" \
+        -var rocm_kernel="linux-image-generic-hwe-22.04" \
+        -var rocm_extras="mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04" \
         -var rocm_builder_disk="70G" \
         -only=qemu.rocm .
     ```
@@ -72,8 +72,8 @@ Variables noted in [I/O](#io) may be given like so: `ansible-pull ... -e 'var=va
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
 | `rocm_releases` | One or more versions to include _[as a comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. | `mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*` |
-| `rocm_kernel` | The kernel package with an optional release specifier.<br/>Headers/others may be defined in `rocm_extras` | `linux-image-generic-hwe-22.04=5.15.*` |
+| `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04` |
 | `rocm_installed` | If _ROCm_ packages are installed. The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_disk` | Space given to the builder VM; releases compound quickly. | _70G_ |
 | `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -36,8 +36,8 @@
         cmd: >
           packer build
           -var headless={{ headless | default('true') }}
-          -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*') }}
-          -var rocm_kernel={{ rocm_kernel | default('linux-image-generic-hwe-22.04=5.15.*') }}
+          -var rocm_extras={{ rocm_extras | default('mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04') }}
+          -var rocm_kernel={{ rocm_kernel | default('linux-image-generic-hwe-22.04') }}
           -var rocm_releases=\"{{ (rocm_releases | default('6.2.2')) }}\"
           -var rocm_builder_disk={{ rocm_builder_disk | default('70G') }}
           -var rocm_builder_cpus={{ rocm_builder_cpus | default(4) }}

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -11,7 +11,7 @@ variable "rocm_filename" {
 
 variable "rocm_kernel" {
   type = string
-  default = "linux-image-generic-hwe-22.04=5.15.*"
+  default = "linux-image-generic-hwe-22.04"
   description = "The kernel to include with the image. May include version specifier. Software will be compiled against this; define headers/others in 'rocm_extras'"
 }
 
@@ -29,8 +29,8 @@ variable "rocm_installed" {
 
 variable "rocm_extras" {
   type = string
-  default = "mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04=5.15.*"
-  description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]"
+  default = "mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04"
+  description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]. May include release specifiers, '=1.2.3' or globbed"
 }
 
 variable "rocm_builder_cpus" {


### PR DESCRIPTION
Now that both sides of the coin have been tested - `5.15` and `6.8` _(#47)_  - defaulting to the newer release, showing users how to go back if desired.

As-is, images are produced with two kernels. The newer HWE one as requested, but also the generic release as well. Many options exist 😄

After this PR: I can/will remove at least one point of repetition with the defaults - `build.yml` with improved templating can defer to Packer _(`ubuntu-rocm.variables.pkr.hcl`)_