### PR TITLE
packer-rocm/README: include (upstream) 'headless' var in construction

### DIFF
--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -49,7 +49,7 @@
       ansible.builtin.command:
         cmd: >
           packer build
-          {% for _var in packer_vars if vars[_var] is defined %}
+          {% for _var in (packer_vars + ['headless']) if vars[_var] is defined %}
           {{ '-var ' + _var + '=' + vars[_var] }}
           {% endfor %}
           -only=qemu.rocm .

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -49,7 +49,7 @@
       ansible.builtin.command:
         cmd: >
           packer build
-          {% for _var in (packer_vars + ['headless']) if vars[_var] is defined %}
+          {% for _var in (packer_vars + ['headless', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ssh_ubuntu_password', 'ubuntu_release']) if vars[_var] is defined %}
           {{ '-var ' + _var + '=' + vars[_var] }}
           {% endfor %}
           -only=qemu.rocm .


### PR DESCRIPTION
Too-tightly bound the variable discovery. It finds those for the custom image here, not those included with `packer-maas`.