### PR TITLE
packer-rocm: auto prereqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-packer-maas
+**.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "amdchecknode"]
 	path = amdchecknode
 	url = https://github.com/joelandman-amd/amdchecknode.git
+[submodule "packer-rocm/packer-maas"]
+	path = packer-rocm/packer-maas
+	url = https://github.com/canonical/packer-maas.git

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -25,12 +25,12 @@ Place any `.deb` packages to include with the image in `ADA/packer-rocm/ubuntu/p
 
 ```shell
 ansible-playbook ADA/packer-rocm/playbooks/build.yml \
-    -e rocm_releases=6.2.2,6.2.1 \
-    -e rocm_kernel=linux-image-generic-hwe-22.04 \
-    -e rocm_extras=linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers \
+    -e rocm_releases="6.2.2,6.2.1" \
+    -e rocm_kernel="linux-image-generic-hwe-22.04" \
+    -e rocm_extras="linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers" \
     -e rocm_builder_cpus=16 \
-    -e rocm_builder_disk=70G \
-    -e qemu_binary=qemu-kvm \
+    -e rocm_builder_disk="70G" \
+    -e qemu_binary="qemu-kvm" \
     -K
 ```
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -46,7 +46,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | _linux-headers-generic-hwe-22.04_, _mesa-amdgpu-va-drivers_ |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>Comma-separated. May include releases with `=x.y.z` or globbing. | <ul><li>_linux-headers-generic-hwe-22.04_</li><li>_mesa-amdgpu-va-drivers_</li></ul> |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -80,13 +80,13 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers` |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
-| `rocm_installed` | If _ROCm_ packages are installed. The `amdgpu` _driver/extras_ are, always. | `False` |
+| `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |
 | `rocm_builder_disk` | Space given to the builder; releases compound quickly. | _70G_ |
-| `rocm_builder_memory` | Megabytes of memory given to the builder.<br/>Reduction may cause out-of-memory conditions when compiling. | _4096_ |
+| `rocm_builder_memory` | Megabytes of memory given to the builder.<br/>Reduction may cause out-of-memory conditions. | _4096_ |
 | `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |
 | `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA1/bcm5760x_230.2.52.0a.zip) |
-| `niccli_sum` | Optional, string. Checksum to use for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
+| `niccli_sum` | Optional, string. Checksum for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -11,11 +11,6 @@ project.
 
 * [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
-* `qemu`, `qemu-nbd`, `nbd-fuse`, `fuse`, `nbdkit`
-* `nbdkit-{nbd-plugin,plugin-nbd}` _(Fedora/Debian, respectively)_
-* `xorriso` or `genisoimage`
-* `rsync`
-* `git`
 
 ### Playbook
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -9,6 +9,7 @@ project.
 
 ### Prerequisites
 
+* `git`
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
 * _Linux_ host
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -46,7 +46,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>Comma-separated. May include releases with `=x.y.z` or globbing. | <ul><li>_linux-headers-generic-hwe-22.04_</li><li>_mesa-amdgpu-va-drivers_</li></ul> |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>Comma-separated. May include releases with `=x.y.z` or globbing. | `linux-headers-generic-hwe-22.04`<br/>`mesa-amdgpu-va-drivers` |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -74,7 +74,8 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
-| `qemu_binary` | The name _or_ path for the QEMU binary. | `qemu-system-x86_64` |
+| `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
+| `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
 | `rocm_releases` | One or more versions to include _[comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers` |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -17,6 +17,7 @@ project.
 ```shell
 ansible-galaxy collection install ansible.posix community.general
 ansible-pull -U https://github.com/nod-ai/ADA.git packer-rocm/playbooks/build.yml \
+    -e qemu_binary=qemu-kvm \
     -e rocm_releases=6.2.2,6.2.1 \
     -e rocm_kernel=linux-image-generic-hwe-22.04 \
     -e rocm_extras=linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers \
@@ -70,6 +71,7 @@ All of these variables are _optional_. Please see [I/O](#io) for more.
 
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
+| `qemu_binary` | The name _or_ path for the QEMU binary. | `qemu-system-x86_64` |
 | `rocm_releases` | One or more versions to include _[comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers` |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -9,8 +9,8 @@ project.
 
 ### Prerequisites
 
-* [packer](https://developer.hashicorp.com/packer/docs/install)
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
+* _Linux_ host
 
 ### Playbook
 
@@ -22,10 +22,13 @@ ansible-pull -U https://github.com/nod-ai/ADA.git packer-rocm/playbooks/build.ym
     -e rocm_kernel=linux-image-generic-hwe-22.04 \
     -e rocm_extras=linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers \
     -e rocm_builder_cpus=16 \
-    -e rocm_builder_disk=70G
+    -e rocm_builder_disk=70G \
+    -K
 ```
 
-All of these variables are _optional_. Please see [I/O](#io) for more.
+Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host _(repositories and packages)_.
+
+**All** of these variables are _optional_. Please see [I/O](#io) for more.
 
 ### Manual
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -12,11 +12,19 @@ project.
 * `ansible`: [pipx](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) or [pip](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip)
 * _Linux_ host
 
-### Playbook
+### Setup
 
 ```shell
-ansible-galaxy collection install ansible.posix community.general
-ansible-pull -U https://github.com/nod-ai/ADA.git packer-rocm/playbooks/build.yml \
+git clone https://github.com/nod-ai/ADA.git
+ansible-galaxy collection install -r ADA/packer-rocm/requirements.yml
+```
+
+Place any `.deb` packages to include with the image in `ADA/packer-rocm/ubuntu/packages/`
+
+### Build
+
+```shell
+ansible-playbook ADA/packer-rocm/playbooks/build.yml \
     -e rocm_releases=6.2.2,6.2.1 \
     -e rocm_kernel=linux-image-generic-hwe-22.04 \
     -e rocm_extras=linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers \
@@ -29,46 +37,6 @@ ansible-pull -U https://github.com/nod-ai/ADA.git packer-rocm/playbooks/build.ym
 Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host _(repositories and packages)_.
 
 **All** of these variables are _optional_. Please see [I/O](#io) for more.
-
-### Manual
-
-1. Clone repositories:
-
-    ```shell
-    git clone https://github.com/canonical/packer-maas.git
-    git clone https://github.com/nod-ai/ADA.git
-    ```
-
-    Place any `.deb` packages to include with the image in `ADA/packer-rocm/ubuntu/packages/`
-
-2. Copy assets from _ADA_ `packer-rocm` to the _Canonical_ `packer-maas` source:
-
-    ```shell
-    # Repeat '--exclude' with shell expansion, slashes are significant for 'rsync'
-    rsync -avP --exclude={'*.md','LICENSE','NOTICE'} ADA/packer-rocm/ packer-maas/
-    ```
-
-3. Install plugins:
-
-    ```shell
-    cd packer-maas/ubuntu
-    packer init .
-    ```
-
-4. Build
-
-    ```shell
-    # Change working directory to the prepared sources
-    cd packer-maas/ubuntu
-
-    # Build
-    PACKER_LOG=1 packer build \
-        -var rocm_releases="6.2.2,6.2.1" \
-        -var rocm_kernel="linux-image-generic-hwe-22.04" \
-        -var rocm_extras="linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers" \
-        -var rocm_builder_disk="70G" \
-        -only=qemu.rocm .
-    ```
 
 ### I/O
 
@@ -103,8 +71,7 @@ maas admin boot-resources create \
      content@=ubuntu-rocm.tar.gz
 ```
 
-The artifact is named `ubuntu-rocm.tar.gz`. When building with `ansible-pull`, it may be here:  
-`~/.ansible/pull/$HOSTNAME/packer-rocm/packer-maas/ubuntu`
+The artifact will be in `ADA/packer-rocm/packer-maas/ubuntu/`, named `ubuntu-rocm.tar.gz`.
 
 #### Proxy
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -17,12 +17,12 @@ project.
 ```shell
 ansible-galaxy collection install ansible.posix community.general
 ansible-pull -U https://github.com/nod-ai/ADA.git packer-rocm/playbooks/build.yml \
-    -e qemu_binary=qemu-kvm \
     -e rocm_releases=6.2.2,6.2.1 \
     -e rocm_kernel=linux-image-generic-hwe-22.04 \
     -e rocm_extras=linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers \
     -e rocm_builder_cpus=16 \
     -e rocm_builder_disk=70G \
+    -e qemu_binary=qemu-kvm \
     -K
 ```
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -46,7 +46,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04, mesa-amdgpu-va-drivers` |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -76,7 +76,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 |:----------:|-------------|:---------:|
 | `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
-| `rocm_releases` | One or more versions to include _[comma-separated string]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
+| `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers` |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
@@ -86,7 +86,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `rocm_builder_memory` | Megabytes of memory given to the builder.<br/>Reduction may cause out-of-memory conditions. | _4096_ |
 | `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |
 | `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA1/bcm5760x_230.2.52.0a.zip) |
-| `niccli_sum` | Optional, string. Checksum for validating `niccli_url`.<br/>Example: `sha256:abcd1234` | _Undefined_ |
+| `niccli_sum` | _Optional_. Checksum to validate `niccli_url` downloads.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 | `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -46,7 +46,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | `linux-headers-generic-hwe-22.04, mesa-amdgpu-va-drivers` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>May also specify releases with `=x.y.z` or globbed. | _linux-headers-generic-hwe-22.04_, _mesa-amdgpu-va-drivers_ |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -83,12 +83,6 @@
             state: present
             update_cache: true  # ensures Packer repo/contents are in-view
 
-        - name: "Manage clone for 'packer-maas' under ADA"
-          ansible.builtin.git:
-            repo: "https://github.com/canonical/packer-maas.git"
-            dest: "{{ packer_maas_dir }}"
-            version: "{{ packer_maas_tag | default('9046979a9e92bb0303ef47da180b0af29f03332f') }}"  # current latest ('v1.2.0') lacks several relevant fixes, default to known commit
-
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:
             src: "{{ packer_rocm_dir }}/"  # trailing '/' on source is significant; copying *contents* of the dir

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -3,18 +3,50 @@
 # yamllint disable rule:line-length
 - name: Build 'packer-rocm'
   hosts: localhost
-  gather_facts: false
   vars:
+    packer_dist: 'ubuntu'  # placeholder: other distributions may be supported
     packer_rocm_dir: "{{ (playbook_dir, '..') | path_join }}"
     packer_maas_dir: "{{ (packer_rocm_dir, 'packer-maas') | path_join }}"
-    packer_dist: 'ubuntu'
     packer_var_hcl: "{{ (packer_dist, packer_dist + '-rocm.variables.pkr.hcl') | path_join }}"  # eg: 'ubuntu/ubuntu-rocm.variables.pkr.hcl'
-    # input variables are read from Packer HCL; matching instances given to Ansible will override 'packer build'
-    # extra-vars ('-e var=value', host_vars, or group_vars all apply
+    # Ansible is available in more places than our requirements
+    packer_supported_hosts: ['Linux']
+    # Linux *builder host* prereqs
+    packer_prereqs:
+      common:
+        - qemu-kvm   # provides builder as a Virtual Machine; meta-package
+        - git        # 'ansible-pull' requires 'git' to clone; should be installed already
+        - rsync      # synchronize module
+        - xorriso    # cloud-init data
+        - fuse       # pressing final tarball/image
+        - nbdkit     # "
+        - nbdfuse    # "
+      RedHat:
+        - edk2-ovmf  # firmware
+        - e2fsprogs  # provides 'fuse2fs', tarball/image work
+        - nbdkit-nbd-plugin
+      Debian:
+        - ovmf
+        - libnbd-bin
+        - fuse2fs
   tasks:
+
+    - name: Assert supported host
+      tags: ['always']
+      ansible.builtin.assert:
+        that:
+          - ansible_system in packer_supported_hosts
+        fail_msg: "Unsupported host: '{{ ansible_system }}', want: {{ packer_supported_hosts }}"
+
     - name: Preparation
       tags: ['prep']
       block:
+
+        - name: Install Prerequisites
+          become: true
+          ansible.builtin.package:  # if host distribution not listed/supported, use the common names alone
+            name: "{{ packer_prereqs['common'] + (packer_prereqs[ansible_os_family] | default([])) }}"
+            state: present
+
         - name: "Manage clone for 'packer-maas' under ADA"
           ansible.builtin.git:
             repo: "https://github.com/canonical/packer-maas.git"
@@ -35,17 +67,18 @@
           ansible.builtin.command: "packer init {{ (packer_maas_dir, packer_dist) | path_join }}"
           changed_when: false
 
-    - name: Read 'packer-rocm' HCL variables
-      ansible.builtin.command: >
-        awk '$1 == "variable" {print $2}' {{ (packer_rocm_dir, packer_var_hcl) | path_join }}
-      register: packer_rocm_hcl_awk
-      changed_when: false
+        - name: Read 'packer-rocm' HCL variables
+          ansible.builtin.command: >
+            awk '$1 == "variable" {print $2}' {{ (packer_rocm_dir, packer_var_hcl) | path_join }}
+          register: packer_rocm_hcl_awk
+          changed_when: false
 
-    - name: Set 'packer-rocm' vars as build fact
-      ansible.builtin.set_fact:
-        packer_vars: "{{ packer_rocm_hcl_awk.stdout_lines | replace('\"', '') }}"
+        - name: Set 'packer-rocm' vars as build fact
+          ansible.builtin.set_fact:
+            packer_vars: "{{ packer_rocm_hcl_awk.stdout_lines | replace('\"', '') }}"
 
     - name: Build
+      tags: ['build']
       ansible.builtin.command:
         cmd: >
           packer build

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -13,6 +13,7 @@
     # Linux *builder host* prereqs
     packer_prereqs:
       common:
+        - packer
         - qemu-kvm   # provides builder as a Virtual Machine; meta-package
         - git        # 'ansible-pull' requires 'git' to clone; should be installed already
         - rsync      # synchronize module
@@ -41,11 +42,46 @@
       tags: ['prep']
       block:
 
+        - name: Repositories
+          become: true
+          tags: ['repo', 'repos']
+          block:
+
+            - name: 'Packer Repo | RedHat'
+              when: ansible_os_family in ['RedHat']
+              ansible.builtin.get_url:
+                url: "https://rpm.releases.hashicorp.com/{{ packer_rpm_map[ansible_distribution] | default(packer_rpm_map[ansible_os_family]) }}/hashicorp.repo"
+                dest: /etc/yum.repos.d/hashicorp.repo
+                mode: '0644'
+              vars:              # reference: https://developer.hashicorp.com/packer/install
+                packer_rpm_map:  # leverage both 'ansible_distribution' and 'ansible_os_family' facts to construct valid repo spec url
+                  RedHat: RHEL
+                  Fedora: fedora
+                  Amazon: AmazonLinux
+
+            - name: 'Packer Repo Block | Debian'
+              when: ansible_os_family in ['Debian']
+              block:
+
+                - name: 'Packer GPG | Debian'
+                  ansible.builtin.apt_key:
+                    url: https://apt.releases.hashicorp.com/gpg
+                    keyring: /etc/apt/trusted.gpg.d/hashicorp.gpg
+
+                - name: 'Packer Repo | Debian'
+                  ansible.builtin.apt_repository:
+                    repo: >
+                      deb [signed-by=/etc/apt/trusted.gpg.d/hashicorp.gpg]
+                      https://apt.releases.hashicorp.com {{ ansible_lsb.codename }} main
+                    state: present
+                    filename: hashicorp
+
         - name: Install Prerequisites
           become: true
           ansible.builtin.package:  # if host distribution not listed/supported, use the common names alone
             name: "{{ packer_prereqs['common'] + (packer_prereqs[ansible_os_family] | default([])) }}"
             state: present
+            update_cache: true  # ensures Packer repo/contents are in-view
 
         - name: "Manage clone for 'packer-maas' under ADA"
           ansible.builtin.git:

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -5,6 +5,8 @@
   hosts: localhost
   vars:
     packer_dist: 'ubuntu'  # placeholder: other distributions may be supported
+    # system packages assume this path; 'cracklib' (systemd dep) collides with the 'packer' name (in sbin)
+    packer_binary: '/usr/bin/packer'  # PATH reliance may confuse things. override.
     packer_rocm_dir: "{{ (playbook_dir, '..') | path_join }}"
     packer_maas_dir: "{{ (packer_rocm_dir, 'packer-maas') | path_join }}"
     packer_var_hcl: "{{ (packer_dist, packer_dist + '-rocm.variables.pkr.hcl') | path_join }}"  # eg: 'ubuntu/ubuntu-rocm.variables.pkr.hcl'
@@ -13,7 +15,6 @@
     # Linux *builder host* prereqs
     packer_prereqs:
       common:
-        - packer
         - qemu-kvm   # provides builder as a Virtual Machine; meta-package
         - git        # 'ansible-pull' requires 'git' to clone; should be installed already
         - rsync      # synchronize module
@@ -42,9 +43,10 @@
       tags: ['prep']
       block:
 
-        - name: Repositories
+        - name: Packer
           become: true
-          tags: ['repo', 'repos']
+          when: packer_binary is match('/usr/bin/packer')  # only when intending the package-managed executable
+          tags: ['packer']
           block:
 
             - name: 'Packer Repo | RedHat'
@@ -76,12 +78,17 @@
                     state: present
                     filename: hashicorp
 
+            - name: Install 'packer'
+              ansible.builtin.package:
+                name: packer
+                state: present
+                update_cache: true  # ensures Packer repo/contents are in-view
+
         - name: Install Prerequisites
           become: true
           ansible.builtin.package:  # if host distribution not listed/supported, use the common names alone
             name: "{{ packer_prereqs['common'] + (packer_prereqs[ansible_os_family] | default([])) }}"
             state: present
-            update_cache: true  # ensures Packer repo/contents are in-view
 
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:
@@ -94,7 +101,7 @@
               - "--exclude='packer-maas'"
 
         - name: "Ensure Packer plugins are installed"
-          ansible.builtin.command: "packer init {{ (packer_maas_dir, packer_dist) | path_join }}"
+          ansible.builtin.command: "{{ packer_binary }} init {{ (packer_maas_dir, packer_dist) | path_join }}"
           changed_when: false
 
         - name: Read 'packer-rocm' HCL variables
@@ -111,7 +118,7 @@
       tags: ['build']
       ansible.builtin.command:
         cmd: >
-          packer build
+          {{ packer_binary }} build
           {% for _var in (packer_vars + ['headless', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ssh_ubuntu_password', 'ubuntu_release']) if vars[_var] is defined %}
           {{ '-var ' + _var + '=' + vars[_var] }}
           {% endfor %}

--- a/packer-rocm/requirements.yml
+++ b/packer-rocm/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: ansible.posix
+  - name: community.general
+roles: []

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -14,7 +14,7 @@ source "qemu" "rocm" {
   disk_size       = "${var.rocm_builder_disk}"  # Packer seems to have trouble with strings that begin with numbers; explicitly cast
   memory          = var.rocm_builder_memory
   # image/build prefs
-  accelerator     = "kvm"  # or 'none' if KVM is unavailable
+  # accelerator     = "none"  # Packer will try 'kvm', falling back to 'tcg' if necessary
   boot_command    = ["<wait5>e<wait2>", "<down><down><down><end><wait>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
   boot_wait       = "5s"
   efi_boot        = true

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -14,6 +14,7 @@ source "qemu" "rocm" {
   disk_size       = "${var.rocm_builder_disk}"  # Packer seems to have trouble with strings that begin with numbers; explicitly cast
   memory          = var.rocm_builder_memory
   # image/build prefs
+  qemu_binary     = var.qemu_binary
   # accelerator     = "none"  # Packer will try 'kvm', falling back to 'tcg' if necessary
   boot_command    = ["<wait5>e<wait2>", "<down><down><down><end><wait>", "<bs><bs><bs><bs><wait>autoinstall ---<wait><f10>"]
   boot_wait       = "5s"

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -1,3 +1,9 @@
+variable "qemu_binary" {
+  type = string
+  default = "qemu-system-x86_64"
+  description = "The name _or_ path for the QEMU binary."
+}
+
 variable "ubuntu_release" {
   type = string
   default = "22.04.5"


### PR DESCRIPTION
Instead of having the user figure out how to get a laundry list of prerequisites, try to handle them _(on Linux, for RedHat and Debian families)_