### PR TITLE
packer-rocm/submodule: +arg for clone, sync excludes++

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -16,7 +16,7 @@ project.
 ### Setup
 
 ```shell
-git clone https://github.com/nod-ai/ADA.git
+git clone --recurse-submodules https://github.com/nod-ai/ADA.git
 ansible-galaxy collection install -r ADA/packer-rocm/requirements.yml
 ```
 

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -95,9 +95,13 @@
             src: "{{ packer_rocm_dir }}/"  # trailing '/' on source is significant; copying *contents* of the dir
             dest: "{{ packer_maas_dir }}"
             rsync_opts:
+              - "--exclude='.git'"
               - "--exclude='*.md'"
+              - "--exclude='ansible.cfg'"
+              - "--exclude='inventories'"
               - "--exclude='NOTICE'"
               - "--exclude='LICENSE'"
+              - "--exclude='TODO'"
               - "--exclude='packer-maas'"
 
         - name: "Ensure Packer plugins are installed"


### PR DESCRIPTION
Ergonomics for submodules are a bit unusual, note the recursion option. Also: relax the copies in `build.yml`