### PR TITLE
packer-rocm/actions: introduce 'ansible-lint', 'headless'->'hidden'

### DIFF
--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -39,9 +39,9 @@ jobs:
         run: |
           ansible-lint --profile production --parseable --nocolor packer-rocm/
 
-      # if Ansible passes, set up Packer/test HCL. 
-      # challenge: many strict references to 'packer-maas' that are out-of-place until playbook-run.
-
+# Not yet validating HCL, challenge:
+# Many out-of-place references to 'packer-maas' until playbook-run; Packer is strict
+#
 #      - name: Setup `packer`
 #        uses: hashicorp/setup-packer@v3.1.0
 #        id: setup

--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -18,7 +18,8 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-python@v5.2.0
+      - name: Setup Python
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.x"
           cache: 'pip'
@@ -31,7 +32,7 @@ jobs:
 
       - name: Install Ansible and Collections
         run: |
-          pip install ansible-core ansible-lint
+          pip install --no-compile ansible-core ansible-lint
           ansible-galaxy collection install -r packer-rocm/requirements.yml
 
       - name: ansible-lint

--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -1,0 +1,48 @@
+---
+name: Lint 'packer-rocm'
+
+on:
+  push:
+    paths:
+      - 'packer-rocm/**'
+  pull_request:
+    paths:
+      - 'packer-rocm/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5.2.0
+        with:
+          python-version: "3.x"
+          cache: 'pip'
+
+      - name: Cache Ansible Collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible/collections
+          key: ansible-collections-${{ hashFiles('packer-rocm/requirements.yml') }}
+
+      - name: Install Ansible and Collections
+        run: |
+          pip install ansible-core ansible-lint
+          ansible-galaxy collection install -r packer-rocm/requirements.yml
+
+      - name: ansible-lint
+        run: |
+          ansible-lint --profile production --parseable --nocolor packer-rocm/
+
+      # if Ansible passes, set up Packer/test HCL. 
+      # challenge: many strict references to 'packer-maas' that are out-of-place until playbook-run.
+
+#      - name: Setup `packer`
+#        uses: hashicorp/setup-packer@v3.1.0
+#        id: setup
+#        with:
+#          version: "latest"

--- a/.github/workflows/packer-rocm.yaml
+++ b/.github/workflows/packer-rocm.yaml
@@ -10,7 +10,7 @@ on:
       - 'packer-rocm/**'
 
 jobs:
-  lint:
+  ansible-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -1,7 +1,7 @@
 # packer-rocm
 
 [MaaS](https://maas.io/)-enabled [Packer](https://www.packer.io/) images
-with `amdgpu-dkms` and _(optional)_ [ROCm](https://www.amd.com/en/products/software/rocm.html). Builds on the [canonical/packer-maas](https://github.com/canonical/packer-maas/)
+with `amdgpu-dkms` and [ROCm](https://www.amd.com/en/products/software/rocm.html). Builds on the [canonical/packer-maas](https://github.com/canonical/packer-maas/)
 project.
 
 
@@ -35,16 +35,18 @@ ansible-playbook ADA/packer-rocm/playbooks/build.yml \
     -K
 ```
 
-Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host _(repositories and packages)_.
+Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host.
 
-**All** of these variables are _optional_. Please see [I/O](#io) for more.
+Skip host preparation with `-t build`. **All** of these variables are _optional_.
+Please see [I/O](#io) for more.
 
 ### I/O
 
 | Variable | Description | Default |
 |:----------:|-------------|:---------:|
-| `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
+| `hidden` | If the VNC window for the VM is _hidden_ during build.<br/>Adjustment brings _display_ requirements. | `True` |
 | `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
+| `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
 | `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>Comma-separated. May include releases with `=x.y.z` or globbing. | `linux-headers-generic-hwe-22.04`<br/>`mesa-amdgpu-va-drivers` |
@@ -57,7 +59,6 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA1/bcm5760x_230.2.52.0a.zip) |
 | `niccli_sum` | _Optional_. Checksum to validate `niccli_url` downloads.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
-| `headless` | If the VNC window for the VM is _hidden_ during build. | `True` |
 
 #### MaaS
 

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -99,10 +99,11 @@
               - "--exclude='*.md'"
               - "--exclude='ansible.cfg'"
               - "--exclude='inventories'"
+              - "--exclude='requirements.yml'"
+              - "--exclude='packer-maas'"
               - "--exclude='NOTICE'"
               - "--exclude='LICENSE'"
               - "--exclude='TODO'"
-              - "--exclude='packer-maas'"
 
         - name: "Ensure Packer plugins are installed"
           ansible.builtin.command: "{{ packer_binary }} init {{ (packer_maas_dir, packer_dist) | path_join }}"
@@ -123,7 +124,7 @@
       ansible.builtin.command:
         cmd: >
           {{ packer_binary }} build
-          {% for _var in (packer_vars + ['headless', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ssh_ubuntu_password', 'ubuntu_release']) if vars[_var] is defined %}
+          {% for _var in (packer_vars + ['hidden', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ssh_ubuntu_password', 'ubuntu_release']) if vars[_var] is defined %}
           {{ '-var ' + _var + '=' + vars[_var] }}
           {% endfor %}
           -only=qemu.rocm .

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -90,6 +90,23 @@
             name: "{{ packer_prereqs['common'] + (packer_prereqs[ansible_os_family] | default([])) }}"
             state: present
 
+        - name: "Ensure Packer plugins are installed"
+          ansible.builtin.command: "{{ packer_binary }} init {{ (packer_maas_dir, packer_dist) | path_join }}"
+          changed_when: false
+
+    - name: Build
+      tags: ['build']
+      block:
+        - name: Read 'packer-rocm' HCL variables
+          ansible.builtin.command: >
+            awk '$1 == "variable" {print $2}' {{ (packer_rocm_dir, packer_var_hcl) | path_join }}
+          register: packer_rocm_hcl_awk
+          changed_when: false
+
+        - name: Set Packer variables as Ansible fact
+          ansible.builtin.set_fact:
+            packer_vars: "{{ packer_rocm_hcl_awk.stdout_lines | replace('\"', '') }}"
+
         - name: "Synchronize 'packer-maas' with ADA 'packer-rocm' assets"
           ansible.posix.synchronize:
             src: "{{ packer_rocm_dir }}/"  # trailing '/' on source is significant; copying *contents* of the dir
@@ -105,32 +122,17 @@
               - "--exclude='LICENSE'"
               - "--exclude='TODO'"
 
-        - name: "Ensure Packer plugins are installed"
-          ansible.builtin.command: "{{ packer_binary }} init {{ (packer_maas_dir, packer_dist) | path_join }}"
-          changed_when: false
-
-        - name: Read 'packer-rocm' HCL variables
-          ansible.builtin.command: >
-            awk '$1 == "variable" {print $2}' {{ (packer_rocm_dir, packer_var_hcl) | path_join }}
-          register: packer_rocm_hcl_awk
-          changed_when: false
-
-        - name: Set 'packer-rocm' vars as build fact
-          ansible.builtin.set_fact:
-            packer_vars: "{{ packer_rocm_hcl_awk.stdout_lines | replace('\"', '') }}"
-
-    - name: Build
-      tags: ['build']
-      ansible.builtin.command:
-        cmd: >
-          {{ packer_binary }} build
-          {% for _var in (packer_vars + ['hidden', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ssh_ubuntu_password', 'ubuntu_release']) if vars[_var] is defined %}
-          {{ '-var ' + _var + '=' + vars[_var] }}
-          {% endfor %}
-          -only=qemu.rocm .
-        chdir: "{{ build_dir }}"
-        creates: "{{ (build_dir, 'ubuntu-rocm.dd.gz') | path_join }}"  # avoid overwriting - require delete
-      vars:
-        build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
-      environment:
-        PACKER_LOG: '1'  # wanted as str
+        - name: Run 'packer build'
+          ansible.builtin.command:
+            cmd: >
+              {{ packer_binary }} build
+              {% for _var in (packer_vars + ['hidden', 'http_directory', 'http_proxy', 'https_proxy', 'no_proxy', 'ubuntu_release']) if vars[_var] is defined %}
+              {{ '-var ' + _var + '=' + vars[_var] }}
+              {% endfor %}
+              -only=qemu.rocm .
+            chdir: "{{ build_dir }}"
+            creates: "{{ (build_dir, 'ubuntu-rocm.dd.gz') | path_join }}"  # avoid overwriting - require delete
+          vars:
+            build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
+          environment:
+            PACKER_LOG: '1'  # wanted as str

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -4,8 +4,8 @@ source "qemu" "rocm" {
   iso_target_path = "packer_cache/ubuntu-${var.ubuntu_release}.iso"
   iso_url         = "https://releases.ubuntu.com/${var.ubuntu_release}/ubuntu-${var.ubuntu_release}-live-server-amd64.iso"
   # cloud-init, note 'cd_files' preserves original names
-  cd_files        = ["meta-data"]
   cd_content      = {
+    "meta-data" = "instance-id: iid-local01\nlocal-hostname: packer-rocm"
     "user-data" = file("${path.root}/user-data-rocm")  # workaround for '-rocm' suffix; cloud-init expects 'user-data'
   }
   cd_label        = "cidata"
@@ -21,12 +21,11 @@ source "qemu" "rocm" {
   efi_boot        = true
   efi_drop_efivars = true  # don't place efivars.fd in output artifact
   format          = "raw"  # qcow2 may not be converted. if written to drives, can't be read back/won't find 'curtin'
-  headless        = var.headless
-  http_directory  = var.http_directory
+  headless        = var.hidden
   shutdown_command       = "sudo -S shutdown -P now"
   ssh_handshake_attempts = 500
   ssh_username           = "ubuntu"
-  ssh_password           = var.ssh_ubuntu_password
+  ssh_password           = "ubuntu"
   ssh_wait_timeout       = "1h"
   ssh_timeout            = "1h"
   # debug/discard

--- a/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.pkr.hcl
@@ -5,7 +5,7 @@ source "qemu" "rocm" {
   iso_url         = "https://releases.ubuntu.com/${var.ubuntu_release}/ubuntu-${var.ubuntu_release}-live-server-amd64.iso"
   # cloud-init, note 'cd_files' preserves original names
   cd_content      = {
-    "meta-data" = "instance-id: iid-local01\nlocal-hostname: packer-rocm"
+    "meta-data" = jsonencode({"instance-id"="iid-local01","local-hostname"="packer-rocm"})
     "user-data" = file("${path.root}/user-data-rocm")  # workaround for '-rocm' suffix; cloud-init expects 'user-data'
   }
   cd_label        = "cidata"

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -1,3 +1,9 @@
+variable "hidden" {
+  type = bool
+  default = true
+  description = "If the VNC display for the Virtual Machine is hidden while building the image. Adds display requirements"
+}
+
 variable "qemu_binary" {
   type = string
   default = "qemu-system-x86_64"


### PR DESCRIPTION
Want to keep the Ansible bits in good shape, adding `ansible-lint`.

Some preparations for `packer validate` as well... but that has challenges. The files need assembled 'just so' first, as if building.