### PR TITLE
packer-rocm: minor fixes

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -26,6 +26,7 @@ Place any `.deb` packages to include with the image in `ADA/packer-rocm/ubuntu/p
 
 ```shell
 ansible-playbook ADA/packer-rocm/playbooks/build.yml \
+    -e rocm_installed=true \
     -e rocm_releases="6.2.2,6.2.1" \
     -e rocm_kernel="linux-image-generic-hwe-22.04" \
     -e rocm_extras="linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers" \

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -4,7 +4,6 @@
 with `amdgpu-dkms` and [ROCm](https://www.amd.com/en/products/software/rocm.html). Builds on the [canonical/packer-maas](https://github.com/canonical/packer-maas/)
 project.
 
-
 ## Building
 
 ### Prerequisites

--- a/packer-rocm/playbooks/build.yml
+++ b/packer-rocm/playbooks/build.yml
@@ -122,7 +122,7 @@
               - "--exclude='LICENSE'"
               - "--exclude='TODO'"
 
-        - name: Run 'packer build'
+        - name: "Run 'packer build', create '{{ _creates | basename }}'"
           ansible.builtin.command:
             cmd: >
               {{ packer_binary }} build
@@ -131,8 +131,10 @@
               {% endfor %}
               -only=qemu.rocm .
             chdir: "{{ build_dir }}"
-            creates: "{{ (build_dir, 'ubuntu-rocm.dd.gz') | path_join }}"  # avoid overwriting - require delete
+            creates: "{{ _creates }}"  # avoid overwriting - require delete
           vars:
-            build_dir: "{{ (packer_maas_dir, 'ubuntu') | path_join }}"
+            build_dir: "{{ (packer_maas_dir, packer_dist) | path_join }}"
+            _filename: "{{ rocm_filename | default(packer_dist + '-rocm.tar.gz') }}"
+            _creates: "{{ (build_dir, _filename) | path_join }}"
           environment:
             PACKER_LOG: '1'  # wanted as str


### PR DESCRIPTION
- fix: demonstrate `rocm_installed=true` usage in `README` 
  - _[originally]_ showed many releases in the request... but _ROCm_ is not installed by default, only the `amdgpu` driver.
  - without `rocm_installed=true`, only the highest release is used _[for the driver]._
- fix: use `packer_dist` when setting the `packer build` working directory
- QoL: show image file name in `packer build` task