### PR TITLE
packer-rocm/README+vars: note 'extras' w/ non-HWE, +placeholder

### DIFF
--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -37,7 +37,7 @@ ansible-playbook ADA/packer-rocm/playbooks/build.yml \
 
 Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host, skip with `-t build`.
 
-**All** of these variables are _optional_. Please see [I/O](#io) for more. _If changing the kernel:_ include the `extra-modules` and `headers` packages for support.
+**All** of these variables are _optional_. Please see [I/O](#io) for more. _If changing the kernel:_ include `extra-modules` and `headers` for support.
 
 ### I/O
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -28,17 +28,16 @@ ansible-playbook ADA/packer-rocm/playbooks/build.yml \
     -e rocm_installed=true \
     -e rocm_releases="6.2.2,6.2.1" \
     -e rocm_kernel="linux-image-generic-hwe-22.04" \
-    -e rocm_extras="linux-headers-generic-hwe-22.04,mesa-amdgpu-va-drivers" \
+    -e rocm_extras="linux-headers-generic-hwe-22.04,linux-image-extra-virtual-hwe-22.04,mesa-amdgpu-va-drivers" \
     -e rocm_builder_cpus=16 \
     -e rocm_builder_disk="70G" \
     -e qemu_binary="qemu-kvm" \
     -K
 ```
 
-Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host.
+Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is used to prepare the host, skip with `-t build`.
 
-Skip host preparation with `-t build`. **All** of these variables are _optional_.
-Please see [I/O](#io) for more.
+**All** of these variables are _optional_. Please see [I/O](#io) for more. _If changing the kernel:_ include the `extra-modules` and `headers` packages for support.
 
 ### I/O
 
@@ -49,14 +48,14 @@ Please see [I/O](#io) for more.
 | `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_.<br/>Comma-separated. May include releases with `=x.y.z` or globbing. | `linux-headers-generic-hwe-22.04`<br/>`mesa-amdgpu-va-drivers` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. Comma-separated list.<br/>The `headers` and `extra-modules` packages support both _DKMS_ and compiled modules, as well. | `linux-headers-generic-hwe-22.04`<br/>`linux-image-extra-virtual-hwe-22.04`<br/>`mesa-amdgpu-va-drivers` |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |
 | `rocm_builder_disk` | Space given to the builder; releases compound quickly. | _70G_ |
 | `rocm_builder_memory` | Megabytes of memory given to the builder.<br/>Reduction may cause out-of-memory conditions. | _4096_ |
 | `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |
-| `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA1/bcm5760x_230.2.52.0a.zip) |
+| `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA2/bcm5760x_231.2.63.0a.zip) |
 | `niccli_sum` | _Optional_. Checksum to validate `niccli_url` downloads.<br/>Example: `sha256:abcd1234` | _Undefined_ |
 | `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
 

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -48,7 +48,7 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 | `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
 | `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
 | `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. Comma-separated list.<br/>The `headers` and `extra-modules` packages support both _DKMS_ and compiled modules, as well. | `linux-headers-generic-hwe-22.04`<br/>`linux-image-extra-virtual-hwe-22.04`<br/>`mesa-amdgpu-va-drivers` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. Comma-separated list. | _linux-headers-generic-hwe-22.04,linux-image-extra-virtual-hwe-22.04,mesa-amdgpu-va-drivers_ |
 | `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
 | `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
 | `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |

--- a/packer-rocm/README.md
+++ b/packer-rocm/README.md
@@ -41,23 +41,23 @@ Remove `-K` if your account does _not_ require a passphrase for `sudo`. This is 
 
 ### I/O
 
-| Variable | Description | Default |
-|:----------:|-------------|:---------:|
-| `hidden` | If the VNC window for the VM is _hidden_ during build.<br/>Adjustment brings _display_ requirements. | `True` |
-| `packer_binary` | The name _or_ path for the _Packer_ binary.<br/>Installation skipped if overridden. | `/usr/bin/packer` |
-| `qemu_binary` | The name _or_ path for the _QEMU_ binary. | `qemu-system-x86_64` |
-| `rocm_releases` | One or more versions to include _[comma-separated]_.<br/>Newest selects the `amdgpu` driver. | `6.2.2` |
-| `rocm_kernel` | The kernel package with an optional release specifier. | `linux-image-generic-hwe-22.04` |
-| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. Comma-separated list. | _linux-headers-generic-hwe-22.04,linux-image-extra-virtual-hwe-22.04,mesa-amdgpu-va-drivers_ |
-| `rocm_filename` | The name of the output file/artifact _(tarball)_ | `ubuntu-rocm.tar.gz` |
-| `rocm_installed` | If _ROCm_ multi-release packages are installed.<br/>The `amdgpu` _driver/extras_ are, always. | `False` |
-| `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM. | _4_ |
-| `rocm_builder_disk` | Space given to the builder; releases compound quickly. | _70G_ |
-| `rocm_builder_memory` | Megabytes of memory given to the builder.<br/>Reduction may cause out-of-memory conditions. | _4096_ |
-| `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image. | `True` |
-| `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive. | [Link](https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA2/bcm5760x_231.2.63.0a.zip) |
-| `niccli_sum` | _Optional_. Checksum to validate `niccli_url` downloads.<br/>Example: `sha256:abcd1234` | _Undefined_ |
-| `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included. | `True` |
+| Variable | Description |
+|:----------:|-------------|
+| `hidden` | If the VNC window for the VM is _hidden_ during build. Adjustment brings _display_ requirements.<br/>**Default:** `True` |
+| `packer_binary` | The name _or_ path for the _Packer_ binary. Installation skipped when changed.<br/>**Default:** `/usr/bin/packer` |
+| `qemu_binary` | The name _or_ path for the _QEMU_ binary.<br/>**Default:** `qemu-system-x86_64` |
+| `rocm_releases` | One or more versions to include _[comma-separated]_. Newest selects the `amdgpu` driver.<br/>**Default:** `6.2.2` |
+| `rocm_kernel` | The kernel package with an optional release specifier.<br/>**Default:** `linux-image-generic-hwe-22.04` |
+| `rocm_extras` | Packages to install _before_ `amdgpu-dkms` and _ROCm_. Comma-separated list.<br/>**Default:** _linux-headers-generic-hwe-22.04,linux-image-extra-virtual-hwe-22.04,mesa-amdgpu-va-drivers_ |
+| `rocm_filename` | The name of the output file/artifact _(tarball)_<br/>**Default:** `ubuntu-rocm.tar.gz` |
+| `rocm_installed` | If _ROCm_ multi-release packages are installed. The `amdgpu` driver and extras are, always.<br/>**Default:** `False` |
+| `rocm_builder_cpus` | Number of virtual CPUs given to the builder VM.<br/>**Default:** _4_ |
+| `rocm_builder_disk` | Space given to the builder; releases compound quickly.<br/>**Default:** _70G_ |
+| `rocm_builder_memory` | Megabytes of memory given to the builder. Reduction may cause out-of-memory conditions.<br/>**Default:** _4096_ |
+| `niccli_wanted` | If [niccli](https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/Configuration-adapter/nic-cli-configuration-utility.html) is included in the image.<br/>**Default:** `True` |
+| `niccli_url` | The URL for the _Broadcom_ `niccli` installation archive.<br/>**Default:** `https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA2/bcm5760x_231.2.63.0a.zip` |
+| `niccli_sum` | _Optional_. Checksum to validate `niccli_url` downloads. Example: `sha256:abcd1234`<br/>**Default:** _Undefined_ |
+| `niccli_driver` | If the `bnxt_{en,re}` NIC drivers are included.<br/>**Default:** `True` |
 
 #### MaaS
 

--- a/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
+++ b/packer-rocm/ubuntu/ubuntu-rocm.variables.pkr.hcl
@@ -24,7 +24,7 @@ variable "rocm_filename" {
 variable "rocm_kernel" {
   type = string
   default = "linux-image-generic-hwe-22.04"
-  description = "The kernel to include with the image. May include version specifier. Software will be compiled against this; define headers/others in 'rocm_extras'"
+  description = "The kernel to include with the image. May include version specifier. Software will be compiled against this; define headers/extra-modules/others in 'rocm_extras'"
 }
 
 variable "rocm_releases" {
@@ -41,8 +41,8 @@ variable "rocm_installed" {
 
 variable "rocm_extras" {
   type = string
-  default = "mesa-amdgpu-va-drivers,linux-headers-generic-hwe-22.04"
-  description = "Comma-separated string of extra packages to install [after 'amdgpu-dkms' and ROCm releases]. May include release specifiers, '=1.2.3' or globbed"
+  default = "linux-headers-generic-hwe-22.04,linux-image-extra-virtual-hwe-22.04,mesa-amdgpu-va-drivers"
+  description = "Comma-separated string of extra packages to install [before 'amdgpu-dkms' and ROCm releases]. For headers, extra-modules, and any other packages. May include release specifiers, '=1.2.3' or globbed."
 }
 
 variable "rocm_builder_cpus" {


### PR DESCRIPTION
If using a non-HWE kernel, the included packages seem incomplete. The `bnxt_re` driver didn't load until after `extra-modules` were installed... which provides `uverbs` as a module. This prevented `amdgpu` from loading.

Note the importance of the package in the README without so much detail, include a placeholder/reminder in the vars.