### PR TITLE
Not printing the task ID once the task is completed

### DIFF
--- a/smci_mi300x_platform_amdgpu_alllogs_collection.sh
+++ b/smci_mi300x_platform_amdgpu_alllogs_collection.sh
@@ -67,7 +67,7 @@ log "Task completed!"
 ENTRY_ID=$(curl -s -k -u "$BMC_USERNAME:$BMC_PASSWORD" \
     -X GET "https://$BMC_IP/redfish/v1/Oem/Supermicro/MI300X/TaskService/Tasks/$TASK_ID" \
     | grep -oP '(?<=Entries/)[^"]*')
-log "Entry ID: $ENTRY_ID"
+#log "Entry ID: $ENTRY_ID"
  
 # Step 3: Download All Logs to logs directory
 OUTPUT_DIR="logs"


### PR DESCRIPTION
Removing the print of TASK ID by the log function. I do not believe we need to print it in standard output. It is not an interesting information for end customers.