### PR TITLE
packer-rocm: specify exact release for community.general

### DIFF
--- a/packer-rocm/requirements.yml
+++ b/packer-rocm/requirements.yml
@@ -2,4 +2,5 @@
 collections:
   - name: ansible.posix
   - name: community.general
+    version: '>=6.4.0'  # specificity for the 'persistent' argument for the 'modprobe' module
 roles: []


### PR DESCRIPTION
Resolves:
```
 (item={'name': 'bnxt_en'}) => {"ansible_loop_var": "module", "changed": false, "module": {"name": "bnxt_en"}, "msg": "Unsupported parameters for (community.general.modprobe) module: persistent. Supported parameters include: name, params, state."}
```
... something one may find with some (outdated) _ansible-full_ installations