### PR TITLE
niccli role: use defaults, don't set in play

### DIFF
--- a/packer-rocm/playbooks/niccli.yml
+++ b/packer-rocm/playbooks/niccli.yml
@@ -1,5 +1,6 @@
 ---
 # yamllint disable rule:line-length
+# vim: ft=yaml.ansible
 - name: "Prepare 'niccli' and driver"
   hosts: default
   environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
@@ -7,9 +8,4 @@
     https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"
     no_proxy: "{{ lookup('ansible.builtin.env', 'no_proxy') | default(omit) }}"
   roles:
-    - name: Include 'niccli' Role
-      role: niccli
-      niccli_url: 'https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA2/bcm5760x_231.2.63.0a.zip'
-      niccli_sum: 'sha256:5c46de9addf9284fb48fef1c505c470c85fd4c129045bdd8ee706447bc1bd025'
-
-# vim: ft=yaml.ansible
+    - { role: niccli }

--- a/packer-rocm/playbooks/roles/niccli/defaults/main.yml
+++ b/packer-rocm/playbooks/roles/niccli/defaults/main.yml
@@ -9,7 +9,7 @@
 #   - 'NetXtreme-E Linux Driver'
 #
 # NOTE/Warning: Patterns in URLs have not been consistent enough for templating to make [much] sense. Directories change along with releases.
-niccli_url: 'https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/Thor2/GCA2/bcm5760x_231.2.63.0a.zip'
+niccli_url: 'https://docs.broadcom.com/docs-and-downloads/ethernet-network-adapters/NXE/BRCM_232.1.132.8/bcm_232.1.132.8c.tar.gz'
 
 # 'niccli_sum' deliberately is *not* defaulted with the URL.
 # if users want to change the link... they should not be required to correct or empty the checksum. this should act as opt-in validation, not a requirement.


### PR DESCRIPTION
This change addresses a precedence problem with Ansible. Setting both `niccli_url` and `niccli_sum` immediately under the `role` may take precedence over `-e` _(extra-vars)_ on the command-line.

The role defaults are generally sufficient, there is little need for this. Remove the problematic statements and bump the default release.