### PR TITLE
packer-rocm/external: set 'all' hostspec, suggest '--limit'

### DIFF
--- a/packer-rocm/playbooks/amdgpu_install.yml
+++ b/packer-rocm/playbooks/amdgpu_install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Manage 'amdgpu-install'
-  hosts: default
+  hosts: all
   environment:
     LANG: C  # some tasks process std{out,err}, aim for consistency
     # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'

--- a/packer-rocm/playbooks/niccli.yml
+++ b/packer-rocm/playbooks/niccli.yml
@@ -2,7 +2,7 @@
 # yamllint disable rule:line-length
 # vim: ft=yaml.ansible
 - name: "Prepare 'niccli' and driver"
-  hosts: default
+  hosts: all
   environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
     http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
     https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"

--- a/packer-rocm/playbooks/os_prep.yml
+++ b/packer-rocm/playbooks/os_prep.yml
@@ -2,7 +2,7 @@
 # vim: ft=yaml.ansible
 # This play runs before any others [by Packer, as provisioners]. Provides package repository and RDMA device naming overrides
 - name: OS Preparation
-  hosts: default
+  hosts: all
   become: true
   vars:  # change these with '-e var=...'
     # one may find 'NAME_FALLBACK'/device-driven naming inconsistency with certain packages installed

--- a/packer-rocm/playbooks/package-globber.yml
+++ b/packer-rocm/playbooks/package-globber.yml
@@ -1,7 +1,7 @@
 ---
 # vim: ft=yaml.ansible
 - name: Package Globber  # the Packer 'file' provisioner copies the files to the builder VM; this processes/installs
-  hosts: default
+  hosts: all
   become: true
   environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
     http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"

--- a/packer-rocm/playbooks/tuned.yml
+++ b/packer-rocm/playbooks/tuned.yml
@@ -1,7 +1,7 @@
 ---
 # yamllint disable rule:line-length
 - name: "Prepare 'tuned' service+profile"
-  hosts: default
+  hosts: all
   environment:  # may be superfluous for your environment; mapped through Packer HCL with 'ansible_env_vars'
     http_proxy: "{{ lookup('ansible.builtin.env', 'http_proxy') | default(omit) }}"
     https_proxy: "{{ lookup('ansible.builtin.env', 'https_proxy') | default(omit) }}"


### PR DESCRIPTION
As part of the image building with Packer, Ansible was being told to expect hosts in the `default` group in the inventory. This placed an arbitrary restriction on users; hosts hoping to benefit from these Playbooks also had to be placed in that group.

This changes the applicable host spec to `all`; opening the playbook to _any_ inventory hosts. The `--limit` argument may be used to limit scope _(either host or group names are accepted)_